### PR TITLE
Fix new-chat state and lock handoff

### DIFF
--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -79,3 +79,31 @@ export async function migrateRunKey(state: RunState, newConversationId: string):
   if (old !== newConversationId) await chrome.storage.local.remove(runKey(old));
   return next;
 }
+
+/**
+ * Move a pending run to its permanent conversation id without creating a second driver.
+ * The caller already owns the old-id lock and must pause its old-id heartbeat while this
+ * transfer runs.
+ */
+export async function adoptConversationOwnership(
+  state: RunState,
+  newConversationId: string,
+  nonce: string,
+): Promise<RunState | null> {
+  const oldConversationId = state.conversationId;
+  if (oldConversationId === newConversationId) return state;
+
+  const acquired = await acquireTabLock(newConversationId, nonce);
+  if (!acquired) return null;
+
+  let migrated: RunState;
+  try {
+    migrated = await migrateRunKey(state, newConversationId);
+  } catch (error) {
+    await releaseTabLock(newConversationId, nonce);
+    throw error;
+  }
+
+  await releaseTabLock(oldConversationId, nonce);
+  return migrated;
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -3,11 +3,12 @@ import { buildHandoffPrompt } from "../common/prompts";
 import { isActive, newRunState } from "../common/state-machine";
 import {
   acquireTabLock,
+  adoptConversationOwnership,
   heartbeatTabLock,
   loadRun,
   loadSettings,
-  migrateRunKey,
   releaseTabLock,
+  saveRun,
 } from "../common/storage";
 import type { ContentRequest } from "../common/types";
 import { conversationIdFromUrl, watchNavigation } from "./navigation";
@@ -27,10 +28,22 @@ function conversationKeyFromLocation(): string {
   return conversationIdFromUrl(location.href) ?? `pending:${crypto.randomUUID()}`;
 }
 
+function stopHeartbeat(): void {
+  if (heartbeatTimer !== undefined) clearInterval(heartbeatTimer);
+  heartbeatTimer = undefined;
+}
+
+function startHeartbeat(): void {
+  stopHeartbeat();
+  heartbeatTimer = setInterval(() => {
+    void heartbeatTabLock(currentConvId, tabNonce);
+  }, HEARTBEAT_MS);
+}
+
 async function initConversation(convId: string): Promise<void> {
   controller?.dispose();
   controller = null;
-  if (heartbeatTimer !== undefined) clearInterval(heartbeatTimer);
+  stopHeartbeat();
   currentConvId = convId;
 
   const settings = await loadSettings();
@@ -42,9 +55,7 @@ async function initConversation(convId: string): Promise<void> {
     panel?.render(state);
     return;
   }
-  heartbeatTimer = setInterval(() => {
-    void heartbeatTabLock(currentConvId, tabNonce);
-  }, HEARTBEAT_MS);
+  startHeartbeat();
 
   const ctl = new RunController(state, settings, {
     onChange: (s) => panel?.render(s),
@@ -62,17 +73,39 @@ async function initConversation(convId: string): Promise<void> {
   }
 }
 
-function onNavigate(href: string): void {
+async function onNavigate(href: string): Promise<void> {
   const urlConv = conversationIdFromUrl(href);
 
-  // A brand-new chat just got its permanent id — adopt it, don't restart.
+  // A brand-new chat just got its permanent id — transfer both state and driver ownership.
   if (urlConv && currentConvId.startsWith("pending:") && controller) {
     const pendingId = currentConvId;
+    const ctl = controller;
+    stopHeartbeat();
+
+    let migrated;
+    try {
+      migrated = await adoptConversationOwnership(ctl.state, urlConv, tabNonce);
+    } catch (error) {
+      log.warn("failed to adopt permanent conversation id", error);
+      startHeartbeat();
+      return;
+    }
+
+    if (!migrated) {
+      ctl.dispose();
+      controller = null;
+      await releaseTabLock(pendingId, tabNonce);
+      currentConvId = urlConv;
+      const state = (await loadRun(urlConv)) ?? newRunState(urlConv, Date.now());
+      panel?.render(state);
+      log.warn("another tab owns the permanent conversation id; staying passive");
+      return;
+    }
+
     currentConvId = urlConv;
-    controller.adoptConversationId(urlConv);
-    void migrateRunKey(controller.state, urlConv);
-    void releaseTabLock(pendingId, tabNonce);
-    void acquireTabLock(urlConv, tabNonce);
+    ctl.state = migrated;
+    panel?.render(migrated);
+    startHeartbeat();
     log.info("adopted conversation id", urlConv);
     return;
   }
@@ -80,12 +113,12 @@ function onNavigate(href: string): void {
   if (urlConv === currentConvId) return;
   if (!urlConv && currentConvId.startsWith("pending:")) return;
 
-  // Real conversation switch: pause anything active, then re-init for the new one.
+  // Real conversation switch: pause anything active, release ownership, then initialize.
   if (controller && isActive(controller.state)) {
     controller.dispatch({ type: "USER_PAUSE" });
   }
-  void releaseTabLock(currentConvId, tabNonce);
-  void initConversation(urlConv ?? `pending:${crypto.randomUUID()}`);
+  await releaseTabLock(currentConvId, tabNonce);
+  await initConversation(urlConv ?? `pending:${crypto.randomUUID()}`);
 }
 
 async function boot(): Promise<void> {
@@ -102,6 +135,7 @@ async function boot(): Promise<void> {
       if (!controller) return;
       const fresh = newRunState(currentConvId, Date.now());
       controller.state = fresh;
+      void saveRun(fresh).catch((err) => log.warn("state save failed", err));
       panel?.render(fresh);
     },
     getHandoffPrompt: () => (controller ? buildHandoffPrompt(controller.state) : ""),
@@ -115,7 +149,7 @@ async function boot(): Promise<void> {
     void releaseTabLock(currentConvId, tabNonce);
   });
 
-  watchNavigation(onNavigate);
+  watchNavigation((href) => void onNavigate(href));
   await initConversation(conversationKeyFromLocation());
   log.info("Chat FreePT ready");
 }

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -80,3 +80,34 @@ describe("tab lock", () => {
     expect(await storage.acquireTabLock("c1", "tab-c")).toBe(true);
   });
 });
+
+describe("conversation ownership", () => {
+  it("moves the run and transfers the driver lock to the permanent id", async () => {
+    const state = newRunState("pending:abc", 1);
+    await storage.saveRun(state);
+    await storage.acquireTabLock("pending:abc", "tab-a");
+
+    const migrated = await storage.adoptConversationOwnership(state, "real-id", "tab-a");
+
+    expect(migrated?.conversationId).toBe("real-id");
+    expect(await storage.loadRun("pending:abc")).toBeNull();
+    expect(await storage.loadRun("real-id")).toEqual(migrated);
+    expect(await storage.acquireTabLock("pending:abc", "tab-b")).toBe(true);
+    expect(await storage.acquireTabLock("real-id", "tab-b")).toBe(false);
+  });
+
+  it("does not migrate when another tab owns the permanent id", async () => {
+    const state = newRunState("pending:abc", 1);
+    await storage.saveRun(state);
+    await storage.acquireTabLock("pending:abc", "tab-a");
+    await storage.acquireTabLock("real-id", "tab-b");
+
+    const migrated = await storage.adoptConversationOwnership(state, "real-id", "tab-a");
+
+    expect(migrated).toBeNull();
+    expect(await storage.loadRun("pending:abc")).toEqual(state);
+    expect(await storage.loadRun("real-id")).toBeNull();
+    expect(await storage.acquireTabLock("pending:abc", "tab-c")).toBe(false);
+    expect(await storage.acquireTabLock("real-id", "tab-c")).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #9

## Result
New chats now transfer persisted run state and single-tab driver ownership to the permanent ChatGPT conversation id without leaving the old `pending:*` run behind or continuing as a second driver.

## Implementation
Added a storage-level ownership transfer that acquires the permanent-id lock before migrating state, releases the new lock if migration fails, and releases the old lock only after migration succeeds. Navigation pauses the old heartbeat during transfer, becomes passive when another tab owns the permanent id, and restarts heartbeats only on the adopted id. Starting a new project now persists the fresh run immediately.

## Verification
Added regression tests covering successful state/lock transfer and refusal when another tab owns the permanent conversation. Hosted fast, unit/coverage/build, dependency-audit, and workflow-policy CI are required before merge.

## Risk
Low and localized to conversation identity persistence and tab-lock lifecycle. No manifest, dependency, workflow, or vendored CI control-plane files changed.

## Remaining work
Continue the product audit after this slice merges, with the next independently deliverable gap tracked in its own Issue and PR.