### PR TITLE
Make reply completion resilient to stop-button drift

### DIFF
--- a/src/content/run-controller.ts
+++ b/src/content/run-controller.ts
@@ -197,8 +197,10 @@ export class RunController {
     }
     this.dispatch({ type: "INSERT_OK" });
 
+    this.watcher.expectReply();
     const sent = await clickSend(() => this.watcher.isStreaming());
     if (!sent.ok) {
+      this.watcher.cancelExpectedReply();
       this.dispatch({ type: "SEND_FAIL", detail: sent.error ?? "unknown" });
       return;
     }

--- a/src/content/stream-watch.ts
+++ b/src/content/stream-watch.ts
@@ -124,7 +124,9 @@ export class StreamWatcher {
 
     const quietSince = Math.max(this.lastMutationAt, this.settleStartedAt);
     const quietFor = now - quietSince;
-    const threshold = toolCallIndicatorVisible() ? this.settings.toolQuietMs : this.settings.quietMs;
+    const threshold = toolCallIndicatorVisible()
+      ? this.settings.toolQuietMs
+      : this.settings.quietMs;
     const message = lastAssistantMessage();
     const markerReady =
       quietFor > MARKER_FAST_PATH_MS && message !== null && parseMarker(message.text) !== null;

--- a/src/content/stream-watch.ts
+++ b/src/content/stream-watch.ts
@@ -83,49 +83,59 @@ export class StreamWatcher {
   private tick(): void {
     const now = Date.now();
     const stopVisible = this.isStreaming();
-
     switch (this.state) {
-      case "idle": {
-        if (stopVisible) this.observeReplyStart(now, true);
+      case "idle":
+        this.tickIdle(now, stopVisible);
         break;
-      }
-      case "waiting": {
-        this.checkStuck(now);
-        if (stopVisible || this.assistantTurnChanged()) {
-          this.observeReplyStart(now, stopVisible);
-        }
+      case "waiting":
+        this.tickWaiting(now, stopVisible);
         break;
-      }
-      case "streaming": {
-        this.checkStuck(now);
-        if (!stopVisible) this.enterSettling(now);
+      case "streaming":
+        this.tickStreaming(now, stopVisible);
         break;
-      }
-      case "settling": {
-        this.checkStuck(now);
-        if (stopVisible) {
-          this.state = "streaming";
-          break;
-        }
-        const quietSince = Math.max(this.lastMutationAt, this.settleStartedAt);
-        const quietFor = now - quietSince;
-        const threshold = toolCallIndicatorVisible()
-          ? this.settings.toolQuietMs
-          : this.settings.quietMs;
-
-        const message = lastAssistantMessage();
-        const markerReady =
-          quietFor > MARKER_FAST_PATH_MS && message !== null && parseMarker(message.text) !== null;
-
-        if (markerReady || quietFor > threshold) {
-          const text = message?.text ?? "";
-          log.debug(`reply complete (${markerReady ? "marker fast-path" : "quiescence"})`);
-          this.reset();
-          this.callbacks.onComplete(text);
-        }
+      case "settling":
+        this.tickSettling(now, stopVisible);
         break;
-      }
     }
+  }
+
+  private tickIdle(now: number, stopVisible: boolean): void {
+    if (stopVisible) this.observeReplyStart(now, true);
+  }
+
+  private tickWaiting(now: number, stopVisible: boolean): void {
+    this.checkStuck(now);
+    if (stopVisible || this.assistantTurnChanged()) {
+      this.observeReplyStart(now, stopVisible);
+    }
+  }
+
+  private tickStreaming(now: number, stopVisible: boolean): void {
+    this.checkStuck(now);
+    if (!stopVisible) this.enterSettling(now);
+  }
+
+  private tickSettling(now: number, stopVisible: boolean): void {
+    this.checkStuck(now);
+    if (stopVisible) {
+      this.state = "streaming";
+      return;
+    }
+
+    const quietSince = Math.max(this.lastMutationAt, this.settleStartedAt);
+    const quietFor = now - quietSince;
+    const threshold = toolCallIndicatorVisible() ? this.settings.toolQuietMs : this.settings.quietMs;
+    const message = lastAssistantMessage();
+    const markerReady =
+      quietFor > MARKER_FAST_PATH_MS && message !== null && parseMarker(message.text) !== null;
+
+    if (markerReady || quietFor > threshold) this.complete(message?.text ?? "", markerReady);
+  }
+
+  private complete(text: string, markerReady: boolean): void {
+    log.debug(`reply complete (${markerReady ? "marker fast-path" : "quiescence"})`);
+    this.reset();
+    this.callbacks.onComplete(text);
   }
 
   private assistantTurnChanged(): boolean {

--- a/src/content/stream-watch.ts
+++ b/src/content/stream-watch.ts
@@ -1,6 +1,6 @@
+import { log } from "../common/log";
 import { parseMarker } from "../common/marker";
 import type { Settings } from "../common/types";
-import { log } from "../common/log";
 import { query } from "./selectors";
 import { conversationRootEl, lastAssistantMessage, toolCallIndicatorVisible } from "./transcript";
 
@@ -10,16 +10,15 @@ export interface StreamCallbacks {
   onStuck: () => void;
 }
 
-type WatchState = "idle" | "streaming" | "settling";
+type WatchState = "idle" | "waiting" | "streaming" | "settling";
 
 const TICK_MS = 800;
 const MARKER_FAST_PATH_MS = 1200;
 
 /**
- * Streaming detection composed from three signals, because each alone lies:
- * the stop button (flickers during MCP tool calls), mutation quiescence (pauses during
- * long tool calls), and — strongest for our protocol — a parseable status marker in the
- * settled text.
+ * Streaming detection composed from independent signals: an explicit expectation after
+ * this extension sends, the stop button, assistant-turn mutations, and settled marker
+ * text. No single ChatGPT DOM affordance is trusted as the only source of truth.
  */
 export class StreamWatcher {
   private state: WatchState = "idle";
@@ -27,6 +26,9 @@ export class StreamWatcher {
   private settleStartedAt = 0;
   private streamStartedAt = 0;
   private stuckReported = false;
+  private replyObserved = false;
+  private baselineElement: HTMLElement | null = null;
+  private baselineText = "";
   private timer: ReturnType<typeof setInterval> | undefined;
   private observer: MutationObserver | undefined;
 
@@ -53,7 +55,25 @@ export class StreamWatcher {
     this.timer = undefined;
     this.observer?.disconnect();
     this.observer = undefined;
-    this.state = "idle";
+    this.reset();
+  }
+
+  /** Arm before clicking Send so a missing stop button cannot strand the reply lifecycle. */
+  expectReply(): void {
+    const message = lastAssistantMessage();
+    this.baselineElement = message?.el ?? null;
+    this.baselineText = message?.text ?? "";
+    this.state = "waiting";
+    this.streamStartedAt = Date.now();
+    this.lastMutationAt = this.streamStartedAt;
+    this.settleStartedAt = 0;
+    this.stuckReported = false;
+    this.replyObserved = false;
+  }
+
+  /** Sending failed, so the armed reply must not consume a later unrelated assistant turn. */
+  cancelExpectedReply(): void {
+    this.reset();
   }
 
   isStreaming(): boolean {
@@ -66,29 +86,23 @@ export class StreamWatcher {
 
     switch (this.state) {
       case "idle": {
-        if (stopVisible) {
-          this.state = "streaming";
-          this.streamStartedAt = now;
-          this.stuckReported = false;
-          this.callbacks.onStart();
+        if (stopVisible) this.observeReplyStart(now, true);
+        break;
+      }
+      case "waiting": {
+        this.checkStuck(now);
+        if (stopVisible || this.assistantTurnChanged()) {
+          this.observeReplyStart(now, stopVisible);
         }
         break;
       }
       case "streaming": {
-        if (
-          !this.stuckReported &&
-          now - this.streamStartedAt > this.settings.maxStreamMinutes * 60_000
-        ) {
-          this.stuckReported = true;
-          this.callbacks.onStuck();
-        }
-        if (!stopVisible) {
-          this.state = "settling";
-          this.settleStartedAt = now;
-        }
+        this.checkStuck(now);
+        if (!stopVisible) this.enterSettling(now);
         break;
       }
       case "settling": {
+        this.checkStuck(now);
         if (stopVisible) {
           this.state = "streaming";
           break;
@@ -104,13 +118,62 @@ export class StreamWatcher {
           quietFor > MARKER_FAST_PATH_MS && message !== null && parseMarker(message.text) !== null;
 
         if (markerReady || quietFor > threshold) {
-          this.state = "idle";
           const text = message?.text ?? "";
           log.debug(`reply complete (${markerReady ? "marker fast-path" : "quiescence"})`);
+          this.reset();
           this.callbacks.onComplete(text);
         }
         break;
       }
     }
+  }
+
+  private assistantTurnChanged(): boolean {
+    const message = lastAssistantMessage();
+    if (!message) return false;
+    if (!this.baselineElement) return true;
+    return message.el !== this.baselineElement || message.text !== this.baselineText;
+  }
+
+  private observeReplyStart(now: number, stopVisible: boolean): void {
+    if (!this.replyObserved) {
+      this.replyObserved = true;
+      if (this.streamStartedAt === 0) this.streamStartedAt = now;
+      this.stuckReported = false;
+      this.callbacks.onStart();
+    }
+    if (stopVisible) {
+      this.state = "streaming";
+      return;
+    }
+    this.enterSettling(now);
+  }
+
+  private enterSettling(now: number): void {
+    this.state = "settling";
+    this.settleStartedAt = now;
+    this.lastMutationAt = now;
+  }
+
+  private checkStuck(now: number): void {
+    if (
+      !this.stuckReported &&
+      this.streamStartedAt > 0 &&
+      now - this.streamStartedAt > this.settings.maxStreamMinutes * 60_000
+    ) {
+      this.stuckReported = true;
+      this.callbacks.onStuck();
+    }
+  }
+
+  private reset(): void {
+    this.state = "idle";
+    this.lastMutationAt = 0;
+    this.settleStartedAt = 0;
+    this.streamStartedAt = 0;
+    this.stuckReported = false;
+    this.replyObserved = false;
+    this.baselineElement = null;
+    this.baselineText = "";
   }
 }

--- a/tests/stream-watch.test.ts
+++ b/tests/stream-watch.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "../src/common/types";
+import { StreamWatcher } from "../src/content/stream-watch";
+
+const SETTINGS = {
+  ...DEFAULT_SETTINGS,
+  quietMs: 1_600,
+  toolQuietMs: 3_200,
+  maxStreamMinutes: 1,
+};
+
+let watcher: StreamWatcher | null = null;
+
+function assistant(id: string, text: string): HTMLElement {
+  const el = document.createElement("div");
+  el.dataset["messageAuthorRole"] = "assistant";
+  el.dataset["messageId"] = id;
+  el.textContent = text;
+  return el;
+}
+
+function main(): HTMLElement {
+  return document.querySelector("main") as HTMLElement;
+}
+
+async function advance(ms: number): Promise<void> {
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(ms);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.body.innerHTML = "<main></main>";
+});
+
+afterEach(() => {
+  watcher?.stop();
+  watcher = null;
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("StreamWatcher", () => {
+  it("starts and completes from a new assistant turn without a stop button", async () => {
+    main().appendChild(assistant("old", "previous reply"));
+    const onStart = vi.fn();
+    const onComplete = vi.fn();
+    const onStuck = vi.fn();
+    watcher = new StreamWatcher({ onStart, onComplete, onStuck }, SETTINGS);
+    watcher.start();
+    watcher.expectReply();
+
+    main().appendChild(
+      assistant(
+        "new",
+        "Finished the next step.\nCHATFREEPT_STATUS: CONTINUE\nV: 1\nPHASE: DEVELOPING",
+      ),
+    );
+    await advance(3_200);
+
+    expect(document.querySelector('[data-testid="stop-button"]')).toBeNull();
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete.mock.calls[0]?.[0]).toContain("CHATFREEPT_STATUS: CONTINUE");
+    expect(onStuck).not.toHaveBeenCalled();
+  });
+
+  it("does not treat the baseline assistant turn as a new reply", async () => {
+    main().appendChild(assistant("old", "previous reply"));
+    const onStart = vi.fn();
+    const onComplete = vi.fn();
+    watcher = new StreamWatcher({ onStart, onComplete, onStuck: vi.fn() }, SETTINGS);
+    watcher.start();
+    watcher.expectReply();
+
+    await advance(8_000);
+
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("still uses the stop button as an independent reply-start signal", async () => {
+    const onStart = vi.fn();
+    const onComplete = vi.fn();
+    watcher = new StreamWatcher({ onStart, onComplete, onStuck: vi.fn() }, SETTINGS);
+    watcher.start();
+
+    const stop = document.createElement("button");
+    stop.dataset["testid"] = "stop-button";
+    main().appendChild(stop);
+    await advance(800);
+    expect(onStart).toHaveBeenCalledTimes(1);
+
+    main().appendChild(
+      assistant("new", "Done.\nCHATFREEPT_STATUS: CONTINUE\nV: 1\nPHASE: DEVELOPING"),
+    );
+    stop.remove();
+    await advance(3_200);
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels an armed expectation after a failed send", async () => {
+    main().appendChild(assistant("old", "previous reply"));
+    const onStart = vi.fn();
+    const onComplete = vi.fn();
+    watcher = new StreamWatcher({ onStart, onComplete, onStuck: vi.fn() }, SETTINGS);
+    watcher.start();
+    watcher.expectReply();
+    watcher.cancelExpectedReply();
+
+    main().appendChild(
+      assistant("unrelated", "Later manual reply.\nCHATFREEPT_STATUS: CONTINUE\nV: 1"),
+    );
+    await advance(4_000);
+
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("reports a stuck armed reply even when the stop button never appears", async () => {
+    const onStuck = vi.fn();
+    watcher = new StreamWatcher(
+      { onStart: vi.fn(), onComplete: vi.fn(), onStuck },
+      { ...SETTINGS, maxStreamMinutes: 0.001 },
+    );
+    watcher.start();
+    watcher.expectReply();
+
+    await advance(1_600);
+
+    expect(onStuck).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #12

## Result
Autonomous runs no longer depend on ChatGPT's stop button as the only signal that a model reply started. The watcher can now follow a newly created or mutated assistant turn from send through settled completion even when the stop-button selector is absent.

## Implementation
`StreamWatcher` now supports an armed waiting state with a pre-send assistant-turn baseline. A reply starts when either the stop button appears or the newest assistant turn changes, then uses the existing quiescence/marker completion logic. Failed sends cancel the armed expectation so later unrelated replies are not consumed. The armed state is also covered by the stuck-reply timeout. `RunController` arms the watcher immediately before clicking Send and cancels it on send failure.

## Verification
Added jsdom/fake-timer regression tests for stop-button-free start/completion, ignoring the pre-send baseline, preserving the stop-button path, cancelling failed-send expectations, and stuck armed replies. Hosted fast, test/build, dependency-audit, metadata, and workflow-policy gates are required before merge.

## Risk
Localized to reply lifecycle detection. Existing stop-button detection remains as an independent signal; no manifest, dependency, settings, selector registry, or vendored CI files changed.

## Remaining work
After merge, continue the audit with host-DOM selector isolation and broader orchestration integration coverage as separate Issues.