### PR TITLE
Centralize remaining ChatGPT host selectors

### DIFF
--- a/src/content/page-signals.ts
+++ b/src/content/page-signals.ts
@@ -1,5 +1,5 @@
 import type { PageSignal } from "../common/types";
-import { query } from "./selectors";
+import { query, queryAll } from "./selectors";
 
 const RATE_LIMIT_RE =
   /you(?:'|’)?ve (?:hit|reached) (?:your|the) (?:limit|cap)|too many (?:requests|messages)|reached (?:your|the) message (?:limit|cap)|try again (?:later|after)|usage cap/i;
@@ -7,8 +7,9 @@ const CONVERSATION_FULL_RE =
   /maximum (?:conversation )?length|conversation is too long|start a new chat to continue/i;
 
 function alertTexts(): string[] {
-  const nodes = document.querySelectorAll('[role="alert"], [class*="toast"]');
-  return Array.from(nodes, (n) => (n as HTMLElement).innerText ?? "").filter(Boolean);
+  return queryAll("pageAlert")
+    .map((node) => (node as HTMLElement).innerText ?? node.textContent ?? "")
+    .filter(Boolean);
 }
 
 /**

--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -12,7 +12,9 @@ export type TargetId =
   | "userMessage"
   | "conversationRoot"
   | "regenerateButton"
-  | "loginButton";
+  | "loginButton"
+  | "pageAlert"
+  | "toolIndicator";
 
 export interface Candidate {
   css: string;
@@ -85,6 +87,14 @@ const REGISTRY: Record<TargetId, Target> = {
       { css: "button, a", textRe: /^log in$/i },
     ],
   },
+  pageAlert: {
+    required: false,
+    candidates: [{ css: '[role="alert"], [class*="toast"]' }],
+  },
+  toolIndicator: {
+    required: false,
+    candidates: [{ css: '[data-testid*="tool"]' }],
+  },
 };
 
 function matches(candidate: Candidate, root: ParentNode): Element[] {
@@ -118,6 +128,15 @@ export function resolve(id: TargetId, root: ParentNode = document): Resolution |
 
 export function query(id: TargetId, root: ParentNode = document): Element | null {
   return resolve(id, root)?.element ?? null;
+}
+
+/** All matches from the first viable candidate, preserving registry fallback order. */
+export function queryAll(id: TargetId, root: ParentNode = document): Element[] {
+  for (const candidate of REGISTRY[id].candidates) {
+    const found = matches(candidate, root);
+    if (found.length > 0) return found;
+  }
+  return [];
 }
 
 /** Last match wins — used for "the newest assistant message". */

--- a/src/content/transcript.ts
+++ b/src/content/transcript.ts
@@ -29,7 +29,7 @@ export function lastMessageRole(): "assistant" | "user" | null {
 export function toolCallIndicatorVisible(): boolean {
   const turn = queryLast("assistantMessage") as HTMLElement | null;
   if (!turn) return false;
-  if (turn.querySelector('[data-testid*="tool"]')) return true;
+  if (query("toolIndicator", turn)) return true;
   const probe = turn.parentElement ?? turn;
   const text = (probe.innerText ?? "").slice(0, 400);
   return /\b(Working|Running|Using|Calling|Searching|Reading|Talking to|Connecting)\b(\.\.\.|…)?/.test(

--- a/tests/page-signals.test.ts
+++ b/tests/page-signals.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { scanPageSignals } from "../src/content/page-signals";
+
+beforeEach(() => {
+  document.body.innerHTML = "<main></main>";
+});
+
+describe("scanPageSignals", () => {
+  it("detects a logged-out page", () => {
+    document.querySelector("main")?.insertAdjacentHTML(
+      "beforeend",
+      '<button data-testid="login-button">Log in</button>',
+    );
+    expect(scanPageSignals()).toBe("logged-out");
+  });
+
+  it("detects conversation length alerts", () => {
+    document.querySelector("main")?.insertAdjacentHTML(
+      "beforeend",
+      '<div role="alert">Maximum conversation length reached. Start a new chat to continue.</div>',
+    );
+    expect(scanPageSignals()).toBe("conversation-full");
+  });
+
+  it("detects usage-limit toasts", () => {
+    document.querySelector("main")?.insertAdjacentHTML(
+      "beforeend",
+      '<div class="toast-banner">You have reached your message limit. Try again later.</div>',
+    );
+    expect(scanPageSignals()).toBe("rate-limit");
+  });
+
+  it("detects regenerate controls as network errors", () => {
+    document.querySelector("main")?.insertAdjacentHTML(
+      "beforeend",
+      '<button data-testid="regenerate-thread-error-button">Regenerate</button>',
+    );
+    expect(scanPageSignals()).toBe("network-error");
+  });
+
+  it("returns null on a healthy composer with no alerts", () => {
+    document.querySelector("main")?.insertAdjacentHTML(
+      "beforeend",
+      '<div id="prompt-textarea" contenteditable="true"></div>',
+    );
+    expect(scanPageSignals()).toBeNull();
+  });
+});

--- a/tests/page-signals.test.ts
+++ b/tests/page-signals.test.ts
@@ -1,48 +1,39 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { scanPageSignals } from "../src/content/page-signals";
 
+function append(html: string): void {
+  document.querySelector("main")?.insertAdjacentHTML("beforeend", html);
+}
+
 beforeEach(() => {
   document.body.innerHTML = "<main></main>";
 });
 
 describe("scanPageSignals", () => {
   it("detects a logged-out page", () => {
-    document.querySelector("main")?.insertAdjacentHTML(
-      "beforeend",
-      '<button data-testid="login-button">Log in</button>',
-    );
+    append('<button data-testid="login-button">Log in</button>');
     expect(scanPageSignals()).toBe("logged-out");
   });
 
   it("detects conversation length alerts", () => {
-    document.querySelector("main")?.insertAdjacentHTML(
-      "beforeend",
+    append(
       '<div role="alert">Maximum conversation length reached. Start a new chat to continue.</div>',
     );
     expect(scanPageSignals()).toBe("conversation-full");
   });
 
   it("detects usage-limit toasts", () => {
-    document.querySelector("main")?.insertAdjacentHTML(
-      "beforeend",
-      '<div class="toast-banner">You have reached your message limit. Try again later.</div>',
-    );
+    append('<div class="toast-banner">You have reached your message limit. Try again later.</div>');
     expect(scanPageSignals()).toBe("rate-limit");
   });
 
   it("detects regenerate controls as network errors", () => {
-    document.querySelector("main")?.insertAdjacentHTML(
-      "beforeend",
-      '<button data-testid="regenerate-thread-error-button">Regenerate</button>',
-    );
+    append('<button data-testid="regenerate-thread-error-button">Regenerate</button>');
     expect(scanPageSignals()).toBe("network-error");
   });
 
   it("returns null on a healthy composer with no alerts", () => {
-    document.querySelector("main")?.insertAdjacentHTML(
-      "beforeend",
-      '<div id="prompt-textarea" contenteditable="true"></div>',
-    );
+    append('<div id="prompt-textarea" contenteditable="true"></div>');
     expect(scanPageSignals()).toBeNull();
   });
 });

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { healthCheck, query, queryLast, resolve } from "../src/content/selectors";
+import { healthCheck, query, queryAll, queryLast, resolve } from "../src/content/selectors";
 
 /**
  * Synthetic fixture reflecting chatgpt.com's known structure (composer, send button,
@@ -46,6 +46,20 @@ describe("selector registry", () => {
   it("queryLast returns the newest assistant message", () => {
     const el = queryLast("assistantMessage");
     expect(el?.getAttribute("data-message-id")).toBe("a2");
+  });
+
+  it("queryAll returns all alert and toast matches", () => {
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      '<div role="alert">one</div><div class="toast-banner">two</div>',
+    );
+    expect(queryAll("pageAlert").map((el) => el.textContent)).toEqual(["one", "two"]);
+  });
+
+  it("resolves tool indicators inside a scoped assistant turn", () => {
+    const turn = queryLast("assistantMessage") as HTMLElement;
+    turn.insertAdjacentHTML("beforeend", '<span data-testid="tool-call">GitHub</span>');
+    expect(query("toolIndicator", turn)?.textContent).toBe("GitHub");
   });
 
   it("falls back down the candidate list", () => {


### PR DESCRIPTION
Fixes #14

## Result
All known ChatGPT host-page selector strings used by runtime content logic now live in `src/content/selectors.ts`. Alert/toast scanning and assistant tool-call detection use the same registry boundary as composer, message, send, stop, login, and regenerate detection.

## Implementation
Added optional `pageAlert` and `toolIndicator` registry targets plus `queryAll`, which returns all matches from the first viable registry candidate. `page-signals.ts` now gets alert text through `queryAll("pageAlert")`, while `transcript.ts` resolves tool indicators through `query("toolIndicator", turn)` and retains its text fallback.

## Verification
Extended selector-registry tests for multi-match alerts and scoped tool indicators, and added page-signal regression tests for logged-out, conversation-full, rate-limit, network-error, and healthy states. Hosted metadata, fast, PR test/build, dependency-audit, and workflow-policy gates are required before merge.

## Risk
Low. This is an architectural isolation/refactor with equivalent selectors and preserved text fallbacks; no state-machine, UI, manifest, dependency, settings, or vendored CI files changed.

## Remaining work
After merge, harden passive-tab ownership behavior so a lock-refused tab is explicit and can safely take over after the active owner disappears.