### PR TITLE
Recover passive tab ownership safely

### DIFF
--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -55,10 +55,14 @@ export async function acquireTabLock(conversationId: string, nonce: string): Pro
   return true;
 }
 
-export async function heartbeatTabLock(conversationId: string, nonce: string): Promise<void> {
-  await chrome.storage.local.set({
-    [lockKey(conversationId)]: { nonce, at: Date.now() } satisfies TabLock,
-  });
+/** Refresh only a lock this tab still owns; never overwrite a newer owner after suspension. */
+export async function heartbeatTabLock(conversationId: string, nonce: string): Promise<boolean> {
+  const key = lockKey(conversationId);
+  const found = await chrome.storage.local.get(key);
+  const lock = found[key] as TabLock | undefined;
+  if (!lock || lock.nonce !== nonce) return false;
+  await chrome.storage.local.set({ [key]: { nonce, at: Date.now() } satisfies TabLock });
+  return true;
 }
 
 export async function releaseTabLock(conversationId: string, nonce: string): Promise<void> {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -10,6 +10,7 @@ import {
   releaseTabLock,
   saveRun,
 } from "../common/storage";
+import type { RunState, Settings } from "../common/types";
 import type { ContentRequest } from "../common/types";
 import { conversationIdFromUrl, watchNavigation } from "./navigation";
 import { RunController } from "./run-controller";
@@ -17,12 +18,14 @@ import { require_ } from "./selectors";
 import { Panel } from "./ui/panel";
 
 const HEARTBEAT_MS = 5000;
+const TAKEOVER_RETRY_MS = 5000;
 const tabNonce = crypto.randomUUID();
 
 let panel: Panel | null = null;
 let controller: RunController | null = null;
 let currentConvId = "";
 let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+let takeoverTimer: ReturnType<typeof setTimeout> | undefined;
 
 function conversationKeyFromLocation(): string {
   return conversationIdFromUrl(location.href) ?? `pending:${crypto.randomUUID()}`;
@@ -33,32 +36,28 @@ function stopHeartbeat(): void {
   heartbeatTimer = undefined;
 }
 
+function stopTakeoverRetry(): void {
+  if (takeoverTimer !== undefined) clearTimeout(takeoverTimer);
+  takeoverTimer = undefined;
+}
+
 function startHeartbeat(): void {
   stopHeartbeat();
   heartbeatTimer = setInterval(() => {
-    void heartbeatTabLock(currentConvId, tabNonce);
+    const conversationId = currentConvId;
+    void heartbeatTabLock(conversationId, tabNonce)
+      .then((owned) => {
+        if (!owned) loseOwnership(conversationId);
+      })
+      .catch((error) => log.warn("tab lock heartbeat failed", error));
   }, HEARTBEAT_MS);
 }
 
-async function initConversation(convId: string): Promise<void> {
-  controller?.dispose();
-  controller = null;
-  stopHeartbeat();
-  currentConvId = convId;
-
-  const settings = await loadSettings();
-  const state = (await loadRun(convId)) ?? newRunState(convId, Date.now());
-
-  const locked = await acquireTabLock(convId, tabNonce);
-  if (!locked) {
-    log.warn("another tab is driving this conversation; staying passive");
-    panel?.render(state);
-    return;
-  }
+function startController(state: RunState, settings: Settings): void {
+  stopTakeoverRetry();
   startHeartbeat();
-
   const ctl = new RunController(state, settings, {
-    onChange: (s) => panel?.render(s),
+    onChange: (next) => panel?.render(next),
     onShowModal: () => {
       if (controller) panel?.showCompletionModal(controller.state);
     },
@@ -66,17 +65,84 @@ async function initConversation(convId: string): Promise<void> {
   controller = ctl;
   panel?.render(state);
 
-  // Picking up a run mid-flight after a reload: re-derive position from the live DOM.
   if (isActive(state)) {
     log.info("resuming active run", state.phase, state.status);
-    setTimeout(() => ctl.reconcile(), 2000);
+    setTimeout(() => {
+      if (controller === ctl) ctl.reconcile();
+    }, 2000);
   }
+}
+
+function enterPassive(state: RunState): void {
+  controller?.dispose();
+  controller = null;
+  stopHeartbeat();
+  panel?.render(state, true);
+  scheduleTakeover(state.conversationId);
+}
+
+function scheduleTakeover(conversationId: string): void {
+  stopTakeoverRetry();
+  takeoverTimer = setTimeout(() => void tryTakeover(conversationId), TAKEOVER_RETRY_MS);
+}
+
+async function tryTakeover(conversationId: string): Promise<void> {
+  takeoverTimer = undefined;
+  if (controller || conversationId !== currentConvId) return;
+
+  let acquired = false;
+  try {
+    acquired = await acquireTabLock(conversationId, tabNonce);
+    if (!acquired) {
+      scheduleTakeover(conversationId);
+      return;
+    }
+
+    const [settings, stored] = await Promise.all([loadSettings(), loadRun(conversationId)]);
+    if (controller || conversationId !== currentConvId) {
+      await releaseTabLock(conversationId, tabNonce);
+      return;
+    }
+
+    const state = stored ?? newRunState(conversationId, Date.now());
+    startController(state, settings);
+    log.info("took over conversation after previous tab became inactive");
+  } catch (error) {
+    if (acquired) await releaseTabLock(conversationId, tabNonce);
+    log.warn("conversation ownership retry failed", error);
+    if (!controller && conversationId === currentConvId) scheduleTakeover(conversationId);
+  }
+}
+
+function loseOwnership(conversationId: string): void {
+  if (!controller || conversationId !== currentConvId) return;
+  const state = controller.state;
+  log.warn("conversation ownership moved to another tab; becoming passive");
+  enterPassive(state);
+}
+
+async function initConversation(convId: string): Promise<void> {
+  controller?.dispose();
+  controller = null;
+  stopHeartbeat();
+  stopTakeoverRetry();
+  currentConvId = convId;
+
+  const settings = await loadSettings();
+  const state = (await loadRun(convId)) ?? newRunState(convId, Date.now());
+  const locked = await acquireTabLock(convId, tabNonce);
+  if (!locked) {
+    log.warn("another tab is driving this conversation; staying passive");
+    enterPassive(state);
+    return;
+  }
+
+  startController(state, settings);
 }
 
 async function onNavigate(href: string): Promise<void> {
   const urlConv = conversationIdFromUrl(href);
 
-  // A brand-new chat just got its permanent id — transfer both state and driver ownership.
   if (urlConv && currentConvId.startsWith("pending:") && controller) {
     const pendingId = currentConvId;
     const ctl = controller;
@@ -97,8 +163,8 @@ async function onNavigate(href: string): Promise<void> {
       await releaseTabLock(pendingId, tabNonce);
       currentConvId = urlConv;
       const state = (await loadRun(urlConv)) ?? newRunState(urlConv, Date.now());
-      panel?.render(state);
       log.warn("another tab owns the permanent conversation id; staying passive");
+      enterPassive(state);
       return;
     }
 
@@ -113,7 +179,7 @@ async function onNavigate(href: string): Promise<void> {
   if (urlConv === currentConvId) return;
   if (!urlConv && currentConvId.startsWith("pending:")) return;
 
-  // Real conversation switch: pause anything active, release ownership, then initialize.
+  stopTakeoverRetry();
   if (controller && isActive(controller.state)) {
     controller.dispatch({ type: "USER_PAUSE" });
   }
@@ -146,6 +212,8 @@ async function boot(): Promise<void> {
   });
 
   window.addEventListener("pagehide", () => {
+    stopTakeoverRetry();
+    stopHeartbeat();
     void releaseTabLock(currentConvId, tabNonce);
   });
 

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -260,25 +260,15 @@ export class Panel {
   }
 
   private onClick(e: Event): void {
-    const target = (e.target as HTMLElement).closest("[data-action]");
+    const target = (e.target as HTMLElement).closest("[data-action]") as HTMLElement | null;
     if (!target) return;
-    const action = (target as HTMLElement).dataset["action"];
-    switch (action) {
+    switch (target.dataset["action"]) {
       case "close":
         this.toggle(false);
         break;
-      case "start": {
-        const idea = this.refValue("idea");
-        if (!idea.trim()) return;
-        const mode = this.radioValue("repomode") === "existing" ? "existing" : "new";
-        this.hooks.onEvent({
-          type: "USER_START",
-          idea,
-          repoMode: mode,
-          repoName: this.refValue("reponame").trim(),
-        });
+      case "start":
+        this.startProject();
         break;
-      }
       case "startdev":
         this.hooks.onEvent({ type: "USER_START_DEVELOPMENT" });
         break;
@@ -291,36 +281,56 @@ export class Panel {
       case "sendnow":
         this.hooks.onEvent({ type: "COOLDOWN_ELAPSED" });
         break;
-      case "reply": {
-        const text = this.refValue("reply");
-        if (!text.trim()) return;
-        this.hooks.onEvent({ type: "USER_REPLY", text });
+      case "reply":
+        this.sendReply();
         break;
-      }
-      case "stop": {
-        if (!this.stopArmed) {
-          this.stopArmed = true;
-          (target as HTMLElement).textContent = "Confirm stop";
-          setTimeout(() => {
-            this.stopArmed = false;
-            if (target.isConnected) (target as HTMLElement).textContent = "Stop";
-          }, 3000);
-          return;
-        }
-        this.hooks.onEvent({ type: "USER_STOP" });
+      case "stop":
+        this.stopRun(target);
         break;
-      }
       case "newproject":
         this.hooks.onNewProject();
         break;
-      case "copyhandoff": {
-        const prompt = this.hooks.getHandoffPrompt();
-        void navigator.clipboard.writeText(prompt).then(() => {
-          (target as HTMLElement).textContent = "Copied — paste it into a new chat";
-        });
+      case "copyhandoff":
+        this.copyHandoff(target);
         break;
-      }
     }
+  }
+
+  private startProject(): void {
+    const idea = this.refValue("idea");
+    if (!idea.trim()) return;
+    this.hooks.onEvent({
+      type: "USER_START",
+      idea,
+      repoMode: this.radioValue("repomode") === "existing" ? "existing" : "new",
+      repoName: this.refValue("reponame").trim(),
+    });
+  }
+
+  private sendReply(): void {
+    const text = this.refValue("reply");
+    if (!text.trim()) return;
+    this.hooks.onEvent({ type: "USER_REPLY", text });
+  }
+
+  private stopRun(target: HTMLElement): void {
+    if (!this.stopArmed) {
+      this.stopArmed = true;
+      target.textContent = "Confirm stop";
+      setTimeout(() => {
+        this.stopArmed = false;
+        if (target.isConnected) target.textContent = "Stop";
+      }, 3000);
+      return;
+    }
+    this.hooks.onEvent({ type: "USER_STOP" });
+  }
+
+  private copyHandoff(target: HTMLElement): void {
+    const prompt = this.hooks.getHandoffPrompt();
+    void navigator.clipboard.writeText(prompt).then(() => {
+      target.textContent = "Copied — paste it into a new chat";
+    });
   }
 
   private refValue(ref: string): string {

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -75,30 +75,30 @@ export class Panel {
     this.panelEl.classList.toggle("cfpt-hidden", !show);
   }
 
-  render(state: RunState): void {
-    this.fab.dataset["state"] = fabState(state);
+  render(state: RunState, passive = false): void {
+    this.fab.dataset["state"] = passive ? "attention" : fabState(state);
 
-    const viewKey = `${state.phase}|${state.status}|${state.pauseReason ?? ""}`;
+    const viewKey = `${state.phase}|${state.status}|${state.pauseReason ?? ""}|${passive}`;
     if (viewKey !== this.lastViewKey) {
       this.lastViewKey = viewKey;
       this.stopArmed = false;
-      this.panelEl.innerHTML = this.viewHtml(state);
+      this.panelEl.innerHTML = this.viewHtml(state, passive);
     }
     this.updateDynamic(state);
   }
 
-  private viewHtml(state: RunState): string {
+  private viewHtml(state: RunState, passive: boolean): string {
     return `
       <div class="cfpt-header">
         <span class="cfpt-title">Chat FreePT</span>
         <span class="cfpt-chip" data-phase="${esc(state.phase)}">${esc(phaseLabel(state.phase))}</span>
         <button class="cfpt-btn" data-action="close" style="margin:0;padding:2px 8px">×</button>
       </div>
-      <div class="cfpt-body">${this.bodyHtml(state)}</div>
+      <div class="cfpt-body">${this.bodyHtml(state, passive)}</div>
     `;
   }
 
-  private bodyHtml(state: RunState): string {
+  private bodyHtml(state: RunState, passive: boolean): string {
     const health = healthCheck();
     const warn =
       health.missing.length > 0
@@ -106,6 +106,8 @@ export class Panel {
             health.missing.join(", "),
           )}. Auto-run cannot operate until the extension is updated.</div>`
         : "";
+
+    if (passive) return warn + this.passiveHtml(state);
 
     switch (state.status) {
       case "idle":
@@ -128,6 +130,17 @@ export class Panel {
       default:
         return warn;
     }
+  }
+
+  private passiveHtml(state: RunState): string {
+    return `
+      <h3>Active in another tab</h3>
+      <p class="cfpt-note">Another ChatGPT tab currently owns this conversation. This tab is
+      read-only and will take over automatically if the other tab closes or stops responding.</p>
+      <p class="cfpt-note">Current state: ${esc(phaseLabel(state.phase))} · ${esc(
+        STATUS_LABEL[state.status] ?? state.status,
+      )}</p>
+    `;
   }
 
   private ideaFormHtml(state: RunState): string {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -72,6 +72,23 @@ describe("tab lock", () => {
     expect(await storage.acquireTabLock("c1", "tab-b")).toBe(true);
   });
 
+  it("heartbeats only a lock owned by the same tab", async () => {
+    await storage.acquireTabLock("c1", "tab-a");
+    expect(await storage.heartbeatTabLock("c1", "tab-a")).toBe(true);
+    expect(await storage.heartbeatTabLock("c1", "tab-b")).toBe(false);
+  });
+
+  it("does not let a suspended old owner overwrite a newer owner", async () => {
+    await storage.acquireTabLock("c1", "tab-a");
+    const key = "cfpt:lock:c1";
+    const lock = stores.local[key] as { nonce: string; at: number };
+    stores.local[key] = { ...lock, at: Date.now() - 60_000 };
+
+    expect(await storage.acquireTabLock("c1", "tab-b")).toBe(true);
+    expect(await storage.heartbeatTabLock("c1", "tab-a")).toBe(false);
+    expect(await storage.acquireTabLock("c1", "tab-c")).toBe(false);
+  });
+
   it("release only removes its own lock", async () => {
     await storage.acquireTabLock("c1", "tab-a");
     await storage.releaseTabLock("c1", "tab-b");


### PR DESCRIPTION
Fixes #16

## Result
A ChatGPT tab that cannot acquire a conversation lock now becomes explicitly read-only instead of showing inert controls, and it can safely take over after the active owner disappears. A resumed/suspended old owner can no longer overwrite a newer valid lock via heartbeat.

## Implementation
`heartbeatTabLock` now refreshes only a lock whose nonce still matches and reports ownership loss. The content bootstrap adds passive takeover retries, reloads the latest persisted run/settings only after acquiring the stale lock, stops retries on navigation/unload/success, and transitions back to passive if an active heartbeat discovers ownership moved. Pending-to-permanent lock collisions use the same passive recovery path. `Panel.render` accepts a passive mode that shows a read-only ownership message with no run actions.

## Verification
Extended storage lock tests to verify owned heartbeats succeed, foreign heartbeats fail, and a suspended old owner cannot overwrite a newer owner after stale-lock takeover. Existing migration/stale-lock tests remain in place. Hosted metadata, fast, PR test/build, dependency-audit, security, and workflow-policy gates are required before merge.

## Risk
Moderate and localized to tab ownership lifecycle. The 15-second stale-lock rule and 5-second heartbeat cadence are unchanged. No state-machine strategy, host selectors, manifest, dependencies, or vendored CI files changed.

## Remaining work
After merge, add broader orchestration integration coverage for plan/develop/continue/manual-input/page-signal flows, then harden settings/runtime behavior and package/release readiness.