### PR TITLE
Normalize persisted runtime settings

### DIFF
--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -12,9 +12,7 @@ export const SETTINGS_LIMITS = {
 type NumericSetting = keyof typeof SETTINGS_LIMITS;
 
 function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null
-    ? (value as Record<string, unknown>)
-    : {};
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
 }
 
 function normalizedNumber(
@@ -52,16 +50,8 @@ export function normalizeSettings(value: unknown): Settings {
   const source = asRecord(value);
   return {
     v: DEFAULT_SETTINGS.v,
-    continueMessage: normalizedString(
-      source,
-      "continueMessage",
-      DEFAULT_SETTINGS.continueMessage,
-    ),
-    autoContinueCap: normalizedNumber(
-      source,
-      "autoContinueCap",
-      DEFAULT_SETTINGS.autoContinueCap,
-    ),
+    continueMessage: normalizedString(source, "continueMessage", DEFAULT_SETTINGS.continueMessage),
+    autoContinueCap: normalizedNumber(source, "autoContinueCap", DEFAULT_SETTINGS.autoContinueCap),
     sendDelayMs: normalizedNumber(source, "sendDelayMs", DEFAULT_SETTINGS.sendDelayMs),
     quietMs: normalizedNumber(source, "quietMs", DEFAULT_SETTINGS.quietMs),
     toolQuietMs: normalizedNumber(source, "toolQuietMs", DEFAULT_SETTINGS.toolQuietMs),

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -1,0 +1,85 @@
+import { DEFAULT_SETTINGS, type Settings } from "./types";
+
+export const SETTINGS_LIMITS = {
+  autoContinueCap: { min: 1, max: 500 },
+  sendDelayMs: { min: 2_000, max: 600_000 },
+  quietMs: { min: 1_000, max: 60_000 },
+  toolQuietMs: { min: 1_000, max: 120_000 },
+  maxStreamMinutes: { min: 1, max: 180 },
+  contractRefreshEvery: { min: 1, max: 100 },
+} as const;
+
+type NumericSetting = keyof typeof SETTINGS_LIMITS;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function normalizedNumber(
+  source: Record<string, unknown>,
+  key: NumericSetting,
+  fallback: number,
+): number {
+  const value = source[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  const { min, max } = SETTINGS_LIMITS[key];
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizedString(
+  source: Record<string, unknown>,
+  key: "continueMessage" | "templateRepo",
+  fallback: string,
+): string {
+  const value = source[key];
+  if (typeof value !== "string") return fallback;
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function normalizedBoolean(
+  source: Record<string, unknown>,
+  key: "notificationsEnabled",
+  fallback: boolean,
+): boolean {
+  const value = source[key];
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function normalizeSettings(value: unknown): Settings {
+  const source = asRecord(value);
+  return {
+    v: DEFAULT_SETTINGS.v,
+    continueMessage: normalizedString(
+      source,
+      "continueMessage",
+      DEFAULT_SETTINGS.continueMessage,
+    ),
+    autoContinueCap: normalizedNumber(
+      source,
+      "autoContinueCap",
+      DEFAULT_SETTINGS.autoContinueCap,
+    ),
+    sendDelayMs: normalizedNumber(source, "sendDelayMs", DEFAULT_SETTINGS.sendDelayMs),
+    quietMs: normalizedNumber(source, "quietMs", DEFAULT_SETTINGS.quietMs),
+    toolQuietMs: normalizedNumber(source, "toolQuietMs", DEFAULT_SETTINGS.toolQuietMs),
+    maxStreamMinutes: normalizedNumber(
+      source,
+      "maxStreamMinutes",
+      DEFAULT_SETTINGS.maxStreamMinutes,
+    ),
+    contractRefreshEvery: normalizedNumber(
+      source,
+      "contractRefreshEvery",
+      DEFAULT_SETTINGS.contractRefreshEvery,
+    ),
+    notificationsEnabled: normalizedBoolean(
+      source,
+      "notificationsEnabled",
+      DEFAULT_SETTINGS.notificationsEnabled,
+    ),
+    templateRepo: normalizedString(source, "templateRepo", DEFAULT_SETTINGS.templateRepo),
+  };
+}

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -1,17 +1,16 @@
 import type { RunState, Settings } from "./types";
-import { DEFAULT_SETTINGS } from "./types";
+import { normalizeSettings } from "./settings";
 
 const SETTINGS_KEY = "cfpt:settings";
 const RUN_PREFIX = "cfpt:run:";
 
 export async function loadSettings(): Promise<Settings> {
   const found = await chrome.storage.sync.get(SETTINGS_KEY);
-  const stored = found[SETTINGS_KEY] as Partial<Settings> | undefined;
-  return { ...DEFAULT_SETTINGS, ...stored };
+  return normalizeSettings(found[SETTINGS_KEY]);
 }
 
 export async function saveSettings(settings: Settings): Promise<void> {
-  await chrome.storage.sync.set({ [SETTINGS_KEY]: settings });
+  await chrome.storage.sync.set({ [SETTINGS_KEY]: normalizeSettings(settings) });
 }
 
 export function runKey(conversationId: string): string {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -69,14 +69,14 @@
     <textarea id="continueMessage" rows="2"></textarea>
 
     <label for="autoContinueCap">Auto-continue cap (per phase)</label>
-    <input type="number" id="autoContinueCap" min="1" max="500" />
+    <input type="number" id="autoContinueCap" />
     <p class="hint">The run pauses and notifies you when the cap is reached.</p>
 
     <label for="sendDelaySec">Delay before each auto-continue (seconds)</label>
-    <input type="number" id="sendDelaySec" min="2" max="600" />
+    <input type="number" id="sendDelaySec" />
 
     <label for="quietSec">Quiet time before a reply counts as finished (seconds)</label>
-    <input type="number" id="quietSec" min="1" max="60" />
+    <input type="number" id="quietSec" />
 
     <label for="templateRepo">CI pipeline template repo (owner/name)</label>
     <input type="text" id="templateRepo" />

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -34,11 +34,7 @@ function configureBounds(): void {
     SETTINGS_LIMITS.sendDelayMs.min / 1000,
     SETTINGS_LIMITS.sendDelayMs.max / 1000,
   );
-  setBounds(
-    "quietSec",
-    SETTINGS_LIMITS.quietMs.min / 1000,
-    SETTINGS_LIMITS.quietMs.max / 1000,
-  );
+  setBounds("quietSec", SETTINGS_LIMITS.quietMs.min / 1000, SETTINGS_LIMITS.quietMs.max / 1000);
 }
 
 async function init(): Promise<void> {

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,3 +1,4 @@
+import { normalizeSettings, SETTINGS_LIMITS } from "../common/settings";
 import { loadSettings, saveSettings } from "../common/storage";
 import type { Settings } from "../common/types";
 
@@ -7,27 +8,59 @@ function el<T extends HTMLElement>(id: string): T {
   return found as T;
 }
 
-async function init(): Promise<void> {
-  const settings = await loadSettings();
+function setBounds(id: string, min: number, max: number): void {
+  const input = el<HTMLInputElement>(id);
+  input.min = String(min);
+  input.max = String(max);
+}
+
+function render(settings: Settings): void {
   el<HTMLTextAreaElement>("continueMessage").value = settings.continueMessage;
   el<HTMLInputElement>("autoContinueCap").value = String(settings.autoContinueCap);
   el<HTMLInputElement>("sendDelaySec").value = String(Math.round(settings.sendDelayMs / 1000));
   el<HTMLInputElement>("quietSec").value = String(Math.round(settings.quietMs / 1000));
   el<HTMLInputElement>("templateRepo").value = settings.templateRepo;
   el<HTMLInputElement>("notificationsEnabled").checked = settings.notificationsEnabled;
+}
+
+function configureBounds(): void {
+  setBounds(
+    "autoContinueCap",
+    SETTINGS_LIMITS.autoContinueCap.min,
+    SETTINGS_LIMITS.autoContinueCap.max,
+  );
+  setBounds(
+    "sendDelaySec",
+    SETTINGS_LIMITS.sendDelayMs.min / 1000,
+    SETTINGS_LIMITS.sendDelayMs.max / 1000,
+  );
+  setBounds(
+    "quietSec",
+    SETTINGS_LIMITS.quietMs.min / 1000,
+    SETTINGS_LIMITS.quietMs.max / 1000,
+  );
+}
+
+async function init(): Promise<void> {
+  configureBounds();
+  let settings = await loadSettings();
+  render(settings);
 
   el<HTMLButtonElement>("save").addEventListener("click", () => {
     void (async () => {
-      const next: Settings = {
+      const next = normalizeSettings({
         ...settings,
-        continueMessage: el<HTMLTextAreaElement>("continueMessage").value.trim(),
-        autoContinueCap: clamp(Number(el<HTMLInputElement>("autoContinueCap").value), 1, 500),
-        sendDelayMs: clamp(Number(el<HTMLInputElement>("sendDelaySec").value), 2, 600) * 1000,
-        quietMs: clamp(Number(el<HTMLInputElement>("quietSec").value), 1, 60) * 1000,
-        templateRepo: el<HTMLInputElement>("templateRepo").value.trim(),
+        continueMessage: el<HTMLTextAreaElement>("continueMessage").value,
+        autoContinueCap: el<HTMLInputElement>("autoContinueCap").valueAsNumber,
+        sendDelayMs: el<HTMLInputElement>("sendDelaySec").valueAsNumber * 1000,
+        quietMs: el<HTMLInputElement>("quietSec").valueAsNumber * 1000,
+        templateRepo: el<HTMLInputElement>("templateRepo").value,
         notificationsEnabled: el<HTMLInputElement>("notificationsEnabled").checked,
-      };
+      });
       await saveSettings(next);
+      settings = next;
+      render(settings);
+
       const status = el<HTMLSpanElement>("status");
       status.textContent = "Saved";
       setTimeout(() => {
@@ -35,11 +68,6 @@ async function init(): Promise<void> {
       }, 2000);
     })();
   });
-}
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) return min;
-  return Math.min(max, Math.max(min, value));
 }
 
 void init();

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -17,11 +17,92 @@ describe("settings", () => {
     expect(await storage.loadSettings()).toEqual(DEFAULT_SETTINGS);
   });
 
-  it("merges stored values over defaults", async () => {
-    await storage.saveSettings({ ...DEFAULT_SETTINGS, autoContinueCap: 7 });
-    const settings = await storage.loadSettings();
-    expect(settings.autoContinueCap).toBe(7);
-    expect(settings.quietMs).toBe(DEFAULT_SETTINGS.quietMs);
+  it.each([
+    {
+      name: "malformed values",
+      stored: {
+        v: 99,
+        continueMessage: "   ",
+        autoContinueCap: -10,
+        sendDelayMs: Number.POSITIVE_INFINITY,
+        quietMs: "3000",
+        toolQuietMs: 999_999,
+        maxStreamMinutes: 0,
+        contractRefreshEvery: 1_000,
+        notificationsEnabled: "yes",
+        templateRepo: null,
+        unknownFutureField: "ignored",
+      },
+      expected: {
+        ...DEFAULT_SETTINGS,
+        autoContinueCap: 1,
+        toolQuietMs: 120_000,
+        maxStreamMinutes: 1,
+        contractRefreshEvery: 100,
+      },
+    },
+    {
+      name: "partial legacy values",
+      stored: {
+        v: 0,
+        continueMessage: "  keep going  ",
+        autoContinueCap: 7,
+        notificationsEnabled: false,
+        obsoleteSetting: true,
+      },
+      expected: {
+        ...DEFAULT_SETTINGS,
+        continueMessage: "keep going",
+        autoContinueCap: 7,
+        notificationsEnabled: false,
+      },
+    },
+    {
+      name: "valid values",
+      stored: {
+        v: 1,
+        continueMessage: "  next  ",
+        autoContinueCap: 500,
+        sendDelayMs: 2_000,
+        quietMs: 60_000,
+        toolQuietMs: 120_000,
+        maxStreamMinutes: 180,
+        contractRefreshEvery: 100,
+        notificationsEnabled: false,
+        templateRepo: "  owner/template  ",
+      },
+      expected: {
+        v: 1,
+        continueMessage: "next",
+        autoContinueCap: 500,
+        sendDelayMs: 2_000,
+        quietMs: 60_000,
+        toolQuietMs: 120_000,
+        maxStreamMinutes: 180,
+        contractRefreshEvery: 100,
+        notificationsEnabled: false,
+        templateRepo: "owner/template",
+      },
+    },
+  ])("normalizes $name loaded from sync storage", async ({ stored, expected }) => {
+    stores.sync["cfpt:settings"] = stored;
+    expect(await storage.loadSettings()).toEqual(expected);
+  });
+
+  it("normalizes settings before writing sync storage", async () => {
+    await storage.saveSettings({
+      ...DEFAULT_SETTINGS,
+      autoContinueCap: 999,
+      sendDelayMs: 1,
+      templateRepo: "  owner/template  ",
+    });
+
+    expect(stores.sync["cfpt:settings"]).toEqual({
+      ...DEFAULT_SETTINGS,
+      autoContinueCap: 500,
+      sendDelayMs: 2_000,
+      templateRepo: "owner/template",
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #22

## Result
Persisted extension settings are now normalized before the runtime can consume or store them. Malformed, stale, partial, or externally modified Chrome sync data can no longer inject invalid delays, caps, timeouts, booleans, empty required strings, unknown fields, or stale schema versions into autonomous runs.

## Implementation
Added a pure `normalizeSettings()` boundary with one exported set of numeric safety limits. `loadSettings()` normalizes raw sync data and `saveSettings()` normalizes again before writing. Required strings are trimmed and defaulted when empty/wrong-type, booleans accept only actual booleans, finite numeric fields are clamped to explicit ranges, unknown keys are ignored, missing keys use defaults, and `v` is always normalized to the current schema version. The options page now consumes the same limits and normalization logic instead of maintaining its own clamp implementation or hard-coded HTML bounds.

## Verification
Expanded the storage suite with a table-driven matrix for malformed, partial/legacy, and valid persisted settings, plus a write-time normalization regression. The cases cover non-finite/wrong-type values, out-of-range values, whitespace-only required strings, legacy schema versions, unknown fields, trimming, booleans, missing fields, and boundary values. Hosted metadata, fast deterministic quality, PR test/build, dependency-audit, security, and workflow-policy gates are required before merge.

## Risk
Low and localized to settings validation and the options form. Defaults and the existing documented options ranges are preserved. No run-state schema, orchestration behavior, host selectors, manifest permissions, dependencies, or CI control-plane files changed.

## Remaining work
After merge, audit package/install/release readiness, exercise the built extension artifact, refresh the control Issue, and prepare the `dev` to `master` production promotion only after release gates are clean.