### PR TITLE
Verify and preserve extension release packages

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -55,6 +55,13 @@ jobs:
           cache-dependency-path: ci/requirements-ci.txt
       - run: ./scripts/bootstrap --ci
       - run: ./ci/run release
+      - name: Upload extension package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: chat-freept-${{ github.sha }}
+          path: artifacts/chat-freept.zip
+          if-no-files-found: error
+          retention-days: 30
       - name: Upload regression report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,9 +1,10 @@
 import { build } from "esbuild";
-import { copyFile, mkdir } from "node:fs/promises";
+import { copyFile, mkdir, rm } from "node:fs/promises";
 import { writeIcons } from "./gen-icons.mjs";
 
 const outdir = "dist";
 
+await rm(outdir, { recursive: true, force: true });
 await mkdir(`${outdir}/icons`, { recursive: true });
 
 await build({

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -1,15 +1,11 @@
 // Zip dist/ into artifacts/chat-freept.zip. Uses `zip` where present (CI ubuntu),
 // PowerShell Compress-Archive on Windows dev machines.
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, rm, stat } from "node:fs/promises";
 import { resolve } from "node:path";
+import { verifyDist } from "./verify-package.mjs";
 
-if (!existsSync("dist/manifest.json")) {
-  console.error("dist/ is missing or incomplete — run `npm run build` first.");
-  process.exit(1);
-}
-
+const verified = await verifyDist("dist");
 await mkdir("artifacts", { recursive: true });
 const target = resolve("artifacts/chat-freept.zip");
 await rm(target, { force: true });
@@ -32,4 +28,7 @@ if (has("zip")) {
     { stdio: "inherit" },
   );
 }
-console.info(`packaged ${target}`);
+
+const archive = await stat(target);
+if (archive.size === 0) throw new Error("packaged extension archive is empty");
+console.info(`packaged Chat FreePT ${verified.version}: ${verified.files.length} files -> ${target}`);

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -31,4 +31,6 @@ if (has("zip")) {
 
 const archive = await stat(target);
 if (archive.size === 0) throw new Error("packaged extension archive is empty");
-console.info(`packaged Chat FreePT ${verified.version}: ${verified.files.length} files -> ${target}`);
+console.info(
+  `packaged Chat FreePT ${verified.version}: ${verified.files.length} files -> ${target}`,
+);

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -71,7 +71,7 @@ export async function verifyDist(root = "dist") {
     actual = (await filesUnder(root)).sort();
   } catch (error) {
     if (error?.code === "ENOENT") {
-      throw new Error(`${root}/ is missing — run \`npm run build\` first.`);
+      throw new Error(`${root}/ is missing — run \`npm run build\` first.`, { cause: error });
     }
     throw error;
   }

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,0 +1,99 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+
+const EXPECTED_FILES = [
+  "background.js",
+  "content.js",
+  "icons/icon16.png",
+  "icons/icon48.png",
+  "icons/icon128.png",
+  "manifest.json",
+  "options.html",
+  "options.js",
+].sort();
+
+function portable(path) {
+  return path.split(sep).join("/");
+}
+
+async function filesUnder(root, dir = root) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await filesUnder(root, path)));
+    } else if (entry.isFile()) {
+      files.push(portable(relative(root, path)));
+    }
+  }
+  return files;
+}
+
+function referencedFiles(manifest) {
+  const references = [];
+  const worker = manifest.background?.service_worker;
+  if (typeof worker === "string") references.push(worker);
+  if (typeof manifest.options_page === "string") references.push(manifest.options_page);
+
+  for (const script of manifest.content_scripts ?? []) {
+    for (const file of script.js ?? []) {
+      if (typeof file === "string") references.push(file);
+    }
+  }
+  for (const file of Object.values(manifest.icons ?? {})) {
+    if (typeof file === "string") references.push(file);
+  }
+  return references;
+}
+
+function assertFileSet(actual) {
+  const missing = EXPECTED_FILES.filter((file) => !actual.includes(file));
+  const unexpected = actual.filter((file) => !EXPECTED_FILES.includes(file));
+  if (missing.length === 0 && unexpected.length === 0) return;
+
+  const details = [];
+  if (missing.length) details.push(`missing: ${missing.join(", ")}`);
+  if (unexpected.length) details.push(`unexpected: ${unexpected.join(", ")}`);
+  throw new Error(`invalid dist file set (${details.join("; ")})`);
+}
+
+async function assertNonEmpty(root, files) {
+  for (const file of files) {
+    const info = await stat(join(root, file));
+    if (info.size === 0) throw new Error(`built extension file is empty: ${file}`);
+  }
+}
+
+export async function verifyDist(root = "dist") {
+  let actual;
+  try {
+    actual = (await filesUnder(root)).sort();
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`${root}/ is missing — run \`npm run build\` first.`);
+    }
+    throw error;
+  }
+
+  assertFileSet(actual);
+  await assertNonEmpty(root, actual);
+
+  const manifest = JSON.parse(await readFile(join(root, "manifest.json"), "utf8"));
+  const pkg = JSON.parse(await readFile("package.json", "utf8"));
+  if (manifest.manifest_version !== 3) {
+    throw new Error(`expected Manifest V3, found ${String(manifest.manifest_version)}`);
+  }
+  if (manifest.version !== pkg.version) {
+    throw new Error(`version mismatch: manifest ${manifest.version} != package ${pkg.version}`);
+  }
+
+  const available = new Set(actual);
+  for (const reference of referencedFiles(manifest)) {
+    if (!available.has(reference)) {
+      throw new Error(`manifest references missing file: ${reference}`);
+    }
+  }
+
+  return { files: actual, version: manifest.version };
+}


### PR DESCRIPTION
Fixes #24

## Result
Extension builds and release packages are now deterministic and self-validating. Stale files cannot leak from a prior build into `dist/`, packaging fails when the expected extension file set is missing, empty, or polluted, manifest-referenced assets and Manifest V3/version coherence are verified, and the production release gate preserves the verified installable ZIP as a hosted artifact.

## Implementation
`build.mjs` now removes `dist/` before rebuilding. Added dependency-free `scripts/verify-package.mjs` to recursively inspect the built file set, reject missing/unexpected/empty files, parse the built manifest, require Manifest V3, require the manifest and package versions to match, and ensure content-script/background/options/icon references resolve inside the package. `package.mjs` invokes that verifier before zipping and rejects an empty archive. The production release workflow now uploads `artifacts/chat-freept.zip` with `if-no-files-found: error` after the existing full release stage.

## Verification
The existing PR test/build stage executes `npm run build` followed by `npm run package`, so the new verifier runs on every task PR without adding a second package path. Production release CI runs the same package path through `./ci/run release` and now additionally requires the resulting archive to exist for artifact upload. Hosted metadata, fast deterministic quality, PR test/build, dependency audit, security, and workflow-policy gates must all pass before merge.

## Risk
This PR changes `.github/workflows/ci-release.yml`, so Issue #24 and this PR carry `risk:ci`. The workflow change only preserves an artifact already produced by the existing release stage; it does not change credentials, branch policy, publishing, signing, dependencies, permissions, or production merge authority.

## Remaining work
After merge, refresh the repository control Issue, verify `dev` versus `master`, create the required `type:release` Issue, open the production PR from `dev` to `master`, and merge only after the full production release gate is green.