### PR TITLE
Embed Chat FreePT in the ChatGPT composer

### DIFF
--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -6,6 +6,7 @@
 
 export type TargetId =
   | "composer"
+  | "composerHeader"
   | "sendButton"
   | "stopButton"
   | "assistantMessage"
@@ -33,17 +34,28 @@ const REGISTRY: Record<TargetId, Target> = {
     candidates: [
       { css: "#prompt-textarea" },
       { css: 'div.ProseMirror[contenteditable="true"]' },
-      { css: 'form [contenteditable="true"]' },
+      { css: 'form[data-type="unified-composer"] [contenteditable="true"]' },
       { css: 'main [contenteditable="true"]' },
     ],
   },
+  composerHeader: {
+    required: false,
+    candidates: [
+      { css: "#thread-bottom [data-prompt-textarea-header]" },
+      { css: "main [data-prompt-textarea-header]" },
+      { css: "[data-prompt-textarea-header]" },
+    ],
+  },
   sendButton: {
-    required: true,
+    // ChatGPT intentionally omits Send while the composer is empty. clickSend() waits
+    // for it after prompt insertion, so its idle absence is not a page-health failure.
+    required: false,
     candidates: [
       { css: 'button[data-testid="send-button"]' },
       { css: "#composer-submit-button" },
       { css: 'button[aria-label="Send prompt"]' },
-      { css: 'form button[type="submit"]' },
+      { css: 'button[aria-label="Send"]' },
+      { css: 'form[data-type="unified-composer"] button[type="submit"]' },
       { css: "form button", textRe: /^send$/i },
     ],
   },
@@ -52,26 +64,29 @@ const REGISTRY: Record<TargetId, Target> = {
     candidates: [
       { css: 'button[data-testid="stop-button"]' },
       { css: 'button[aria-label="Stop streaming"]' },
+      { css: 'button[aria-label="Stop generating"]' },
       { css: 'button[aria-label*="Stop"]' },
     ],
   },
   assistantMessage: {
     required: false,
     candidates: [
+      { css: '[data-message-author-role="assistant"][data-message-id]' },
       { css: '[data-message-author-role="assistant"]' },
-      { css: '[data-testid^="conversation-turn"] .agent-turn' },
+      { css: '[data-testid^="conversation-turn"][data-turn="assistant"] .agent-turn' },
     ],
   },
   userMessage: {
     required: false,
     candidates: [
+      { css: '[data-message-author-role="user"][data-message-id]' },
       { css: '[data-message-author-role="user"]' },
-      { css: '[data-testid^="conversation-turn"] .user-turn' },
+      { css: '[data-testid^="conversation-turn"][data-turn="user"] .user-turn' },
     ],
   },
   conversationRoot: {
     required: true,
-    candidates: [{ css: "main" }, { css: "body" }],
+    candidates: [{ css: "#thread" }, { css: "main#main" }, { css: "main" }, { css: "body" }],
   },
   regenerateButton: {
     required: false,

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -1,6 +1,6 @@
 import type { MachineEvent } from "../../common/state-machine";
 import type { RunState } from "../../common/types";
-import { healthCheck } from "../selectors";
+import { healthCheck, query } from "../selectors";
 import { PANEL_CSS } from "./styles";
 
 export interface PanelHooks {
@@ -28,74 +28,117 @@ function esc(text: string): string {
 }
 
 /**
- * The floating launcher + side panel. Rendered inside a closed shadow root so the host
- * page's styles and ours never touch. The body re-renders only when the view key
- * changes; counters and the activity log update in place so textareas keep focus.
+ * Native-style Chat FreePT controls embedded in ChatGPT's composer header slot. A closed
+ * shadow root keeps both style systems isolated, while a subtree observer re-homes the
+ * single host when ChatGPT replaces its composer during SPA navigation or hydration.
  */
 export class Panel {
   private readonly host: HTMLDivElement;
   private readonly shadow: ShadowRoot;
-  private readonly fab: HTMLButtonElement;
+  private readonly dock: HTMLButtonElement;
+  private readonly dockPhase: HTMLSpanElement;
+  private readonly dockStatus: HTMLSpanElement;
+  private readonly chevron: HTMLSpanElement;
   private readonly panelEl: HTMLDivElement;
+  private readonly mountObserver: MutationObserver;
   private lastViewKey = "";
   private stopArmed = false;
+  private mountQueued = false;
 
   constructor(private readonly hooks: PanelHooks) {
     this.host = document.createElement("div");
     this.host.id = "cfpt-root";
+    this.host.dataset["cfptEmbedded"] = "true";
+    this.host.dataset["expanded"] = "false";
     this.shadow = this.host.attachShadow({ mode: "closed" });
 
     const style = document.createElement("style");
     style.textContent = PANEL_CSS;
     this.shadow.appendChild(style);
 
-    this.fab = document.createElement("button");
-    this.fab.className = "cfpt-fab";
-    this.fab.textContent = "FP";
-    this.fab.title = "Chat FreePT";
-    this.fab.addEventListener("click", () => this.toggle());
-    this.shadow.appendChild(this.fab);
-
     this.panelEl = document.createElement("div");
     this.panelEl.className = "cfpt-panel cfpt-hidden";
-    this.panelEl.addEventListener("click", (e) => this.onClick(e));
+    this.panelEl.addEventListener("click", (event) => this.onClick(event));
     this.shadow.appendChild(this.panelEl);
 
-    document.documentElement.appendChild(this.host);
+    this.dock = document.createElement("button");
+    this.dock.type = "button";
+    this.dock.className = "cfpt-dock";
+    this.dock.title = "Chat FreePT controls";
+    this.dock.setAttribute("aria-expanded", "false");
+    this.dock.innerHTML = `
+      <span class="cfpt-mark" aria-hidden="true">FP</span>
+      <span class="cfpt-dock-title">Chat FreePT</span>
+      <span class="cfpt-chip" data-phase="idle">Ready</span>
+      <span class="cfpt-dock-status">Idle</span>
+      <span class="cfpt-chevron" aria-hidden="true">▴</span>
+    `;
+    this.dock.addEventListener("click", () => this.toggle());
+    this.shadow.appendChild(this.dock);
 
-    // The page's framework occasionally rewrites documentElement children; re-attach.
-    const keepAlive = new MutationObserver(() => {
-      if (!this.host.isConnected) document.documentElement.appendChild(this.host);
-    });
-    keepAlive.observe(document.documentElement, { childList: true });
+    this.dockPhase = this.requiredShadowElement<HTMLSpanElement>(".cfpt-chip");
+    this.dockStatus = this.requiredShadowElement<HTMLSpanElement>(".cfpt-dock-status");
+    this.chevron = this.requiredShadowElement<HTMLSpanElement>(".cfpt-chevron");
+
+    this.mountObserver = new MutationObserver(() => this.scheduleMount());
+    this.mountObserver.observe(document.documentElement, { childList: true, subtree: true });
+    this.mount();
   }
 
   toggle(force?: boolean): void {
     const show = force ?? this.panelEl.classList.contains("cfpt-hidden");
     this.panelEl.classList.toggle("cfpt-hidden", !show);
+    this.host.dataset["expanded"] = String(show);
+    this.dock.setAttribute("aria-expanded", String(show));
+    this.chevron.textContent = show ? "▾" : "▴";
   }
 
   render(state: RunState, passive = false): void {
-    this.fab.dataset["state"] = passive ? "attention" : fabState(state);
+    const visualState = passive ? "attention" : dockState(state);
+    this.host.dataset["state"] = visualState;
+    this.host.dataset["status"] = state.status;
+    this.host.dataset["phase"] = state.phase;
+    this.dock.dataset["state"] = visualState;
+    this.dockPhase.dataset["phase"] = state.phase;
+    this.dockPhase.textContent = phaseLabel(state.phase);
+    this.dockStatus.textContent = passive
+      ? "Active in another tab"
+      : (STATUS_LABEL[state.status] ?? state.status);
 
     const viewKey = `${state.phase}|${state.status}|${state.pauseReason ?? ""}|${passive}`;
     if (viewKey !== this.lastViewKey) {
       this.lastViewKey = viewKey;
       this.stopArmed = false;
-      this.panelEl.innerHTML = this.viewHtml(state, passive);
+      this.panelEl.innerHTML = `<div class="cfpt-body">${this.bodyHtml(state, passive)}</div>`;
     }
     this.updateDynamic(state);
+    this.mount();
   }
 
-  private viewHtml(state: RunState, passive: boolean): string {
-    return `
-      <div class="cfpt-header">
-        <span class="cfpt-title">Chat FreePT</span>
-        <span class="cfpt-chip" data-phase="${esc(state.phase)}">${esc(phaseLabel(state.phase))}</span>
-        <button class="cfpt-btn" data-action="close" style="margin:0;padding:2px 8px">×</button>
-      </div>
-      <div class="cfpt-body">${this.bodyHtml(state, passive)}</div>
-    `;
+  dispose(): void {
+    this.mountObserver.disconnect();
+    this.host.remove();
+  }
+
+  private requiredShadowElement<T extends Element>(selector: string): T {
+    const element = this.shadow.querySelector(selector);
+    if (!element) throw new Error(`Chat FreePT shadow element missing: ${selector}`);
+    return element as T;
+  }
+
+  private scheduleMount(): void {
+    if (this.mountQueued) return;
+    this.mountQueued = true;
+    queueMicrotask(() => {
+      this.mountQueued = false;
+      this.mount();
+    });
+  }
+
+  private mount(): void {
+    const anchor = query("composerHeader");
+    if (!anchor || this.host.parentElement === anchor) return;
+    anchor.appendChild(this.host);
   }
 
   private bodyHtml(state: RunState, passive: boolean): string {
@@ -229,7 +272,7 @@ export class Panel {
 
   private completeHtml(state: RunState): string {
     return `
-      <h3>Development complete 🎉</h3>
+      <h3>Development complete</h3>
       ${repoLine(state)}
       <p class="cfpt-note">ChatGPT reports the project is done — verify it at the repo.</p>
       <button class="cfpt-btn cfpt-btn-primary" data-action="newproject">New project</button>
@@ -346,34 +389,9 @@ export class Panel {
     return el?.value ?? "";
   }
 
-  showCompletionModal(state: RunState): void {
-    const existing = this.shadow.querySelector(".cfpt-modal-backdrop");
-    if (existing) existing.remove();
-    const backdrop = document.createElement("div");
-    backdrop.className = "cfpt-modal-backdrop";
-    const repoUrl = state.repo ? `https://github.com/${state.repo}` : undefined;
-    backdrop.innerHTML = `
-      <div class="cfpt-modal">
-        <div class="big">🎉</div>
-        <h2>Development complete</h2>
-        <p>ChatGPT reports every plan item is merged and CI is green${
-          state.repo ? ` on <strong>${esc(state.repo)}</strong>` : ""
-        }. Verify it at the repository.</p>
-        ${
-          repoUrl
-            ? `<a class="cfpt-btn cfpt-btn-primary cfpt-link" style="color:#fff" href="${esc(
-                repoUrl,
-              )}" target="_blank" rel="noreferrer noopener">View repository</a>`
-            : ""
-        }
-        <button class="cfpt-btn" data-close="1">Close</button>
-      </div>
-    `;
-    backdrop.addEventListener("click", (e) => {
-      const el = e.target as HTMLElement;
-      if (el === backdrop || el.dataset["close"]) backdrop.remove();
-    });
-    this.shadow.appendChild(backdrop);
+  showCompletionModal(_state: RunState): void {
+    // Completion stays embedded instead of creating a page-wide overlay.
+    this.toggle(true);
   }
 }
 
@@ -396,7 +414,7 @@ function phaseLabel(phase: string): string {
   }
 }
 
-function fabState(state: RunState): string {
+function dockState(state: RunState): string {
   if (state.status === "error") return "error";
   if (state.status === "awaiting_user") return "attention";
   if (state.status === "complete") return "done";

--- a/src/content/ui/styles.ts
+++ b/src/content/ui/styles.ts
@@ -1,132 +1,165 @@
 export const PANEL_CSS = `
 :host {
   all: initial;
+  display: block;
+  width: 100%;
+  pointer-events: none;
+  color-scheme: inherit;
+  --cfpt-surface: var(--composer-surface-primary, Canvas);
+  --cfpt-text: var(--token-text-primary, CanvasText);
+  --cfpt-muted: var(--token-text-secondary, color-mix(in srgb, CanvasText 65%, transparent));
+  --cfpt-border: var(--token-border-light, color-mix(in srgb, CanvasText 16%, transparent));
+  --cfpt-hover: var(--token-surface-hover, color-mix(in srgb, CanvasText 8%, transparent));
+  --cfpt-accent: var(--theme-submit-btn-bg, #10a37f);
 }
 * {
   box-sizing: border-box;
   font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
-.cfpt-fab {
-  position: fixed;
-  right: 20px;
-  bottom: 88px;
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: none;
-  background: #10a37f;
-  color: #fff;
-  font-size: 20px;
-  font-weight: 700;
-  cursor: pointer;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
-  z-index: 2147483000;
-}
-.cfpt-fab:hover { filter: brightness(1.1); }
-.cfpt-fab[data-state="run"] { animation: cfpt-pulse 1.6s ease-in-out infinite; }
-.cfpt-fab[data-state="attention"] { background: #d97706; }
-.cfpt-fab[data-state="error"] { background: #dc2626; }
-.cfpt-fab[data-state="done"] { background: #2563eb; }
-@keyframes cfpt-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(16, 163, 127, 0.55); }
-  50% { box-shadow: 0 0 0 12px rgba(16, 163, 127, 0); }
-}
-.cfpt-panel {
-  position: fixed;
-  right: 20px;
-  bottom: 148px;
-  width: 380px;
-  max-height: min(72vh, 640px);
-  display: flex;
-  flex-direction: column;
-  background: #202123;
-  color: #ececf1;
-  border: 1px solid #444654;
-  border-radius: 12px;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
-  z-index: 2147483001;
-  overflow: hidden;
-}
-.cfpt-panel.cfpt-hidden { display: none; }
-.cfpt-header {
+button, textarea, input { font: inherit; }
+.cfpt-dock {
+  pointer-events: auto;
+  width: 100%;
+  min-height: 38px;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 14px;
-  background: #2a2b32;
-  border-bottom: 1px solid #444654;
+  border: 1px solid var(--cfpt-border);
+  border-radius: 18px;
+  padding: 6px 10px;
+  background: var(--cfpt-surface);
+  color: var(--cfpt-text);
+  cursor: pointer;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+  text-align: start;
 }
-.cfpt-title { font-weight: 700; font-size: 14px; flex: 1; }
-.cfpt-chip {
-  font-size: 11px;
-  font-weight: 600;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: #444654;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-}
-.cfpt-chip[data-phase="planning"] { background: #0e7490; }
-.cfpt-chip[data-phase="plan_ready"] { background: #a16207; }
-.cfpt-chip[data-phase="developing"] { background: #15803d; }
-.cfpt-chip[data-phase="complete"] { background: #2563eb; }
-.cfpt-body { padding: 14px; overflow-y: auto; font-size: 13px; line-height: 1.45; }
-.cfpt-body h3 { margin: 0 0 8px; font-size: 13px; }
-.cfpt-warn {
-  background: #78350f;
-  color: #fde68a;
-  padding: 8px 10px;
+.cfpt-dock:hover { background: var(--cfpt-hover); }
+.cfpt-dock:focus-visible { outline: 2px solid var(--cfpt-accent); outline-offset: 2px; }
+.cfpt-mark {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
   border-radius: 8px;
+  background: var(--cfpt-accent);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: -0.2px;
+}
+.cfpt-dock[data-state="attention"] .cfpt-mark { background: #d97706; }
+.cfpt-dock[data-state="error"] .cfpt-mark { background: #dc2626; }
+.cfpt-dock[data-state="done"] .cfpt-mark { background: #2563eb; }
+.cfpt-dock[data-state="run"] .cfpt-mark { animation: cfpt-pulse 1.6s ease-in-out infinite; }
+@keyframes cfpt-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--cfpt-accent) 45%, transparent); }
+  50% { box-shadow: 0 0 0 7px transparent; }
+}
+.cfpt-dock-title { font-size: 13px; font-weight: 650; white-space: nowrap; }
+.cfpt-dock-status {
+  min-width: 0;
+  flex: 1;
+  color: var(--cfpt-muted);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cfpt-chip {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 650;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--cfpt-hover);
+  color: var(--cfpt-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.35px;
+}
+.cfpt-chip[data-phase="planning"] { color: #0891b2; }
+.cfpt-chip[data-phase="plan_ready"] { color: #ca8a04; }
+.cfpt-chip[data-phase="developing"] { color: #16a34a; }
+.cfpt-chip[data-phase="complete"] { color: #2563eb; }
+.cfpt-chevron { flex: 0 0 auto; color: var(--cfpt-muted); font-size: 11px; }
+.cfpt-panel {
+  pointer-events: auto;
+  width: 100%;
+  max-height: min(52vh, 520px);
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 8px;
+  background: var(--cfpt-surface);
+  color: var(--cfpt-text);
+  border: 1px solid var(--cfpt-border);
+  border-radius: 18px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.16);
+  overflow: hidden;
+}
+.cfpt-panel.cfpt-hidden { display: none; }
+.cfpt-body { padding: 14px; overflow-y: auto; font-size: 13px; line-height: 1.45; }
+.cfpt-body h3 { margin: 0 0 8px; color: var(--cfpt-text); font-size: 13px; }
+.cfpt-warn {
+  background: color-mix(in srgb, #d97706 18%, var(--cfpt-surface));
+  color: var(--cfpt-text);
+  border: 1px solid color-mix(in srgb, #d97706 38%, transparent);
+  padding: 8px 10px;
+  border-radius: 10px;
   font-size: 12px;
   margin-bottom: 10px;
 }
-.cfpt-note { color: #b4b4bc; font-size: 12px; margin: 8px 0; }
+.cfpt-note { color: var(--cfpt-muted); font-size: 12px; margin: 8px 0; }
 .cfpt-field { margin-bottom: 10px; }
-.cfpt-field label { display: block; font-size: 12px; color: #b4b4bc; margin-bottom: 4px; }
+.cfpt-field label { display: block; font-size: 12px; color: var(--cfpt-muted); margin-bottom: 4px; }
 textarea, input[type="text"] {
   width: 100%;
-  background: #343541;
-  color: #ececf1;
-  border: 1px solid #565869;
-  border-radius: 8px;
-  padding: 8px;
+  background: color-mix(in srgb, var(--cfpt-surface) 92%, CanvasText 8%);
+  color: var(--cfpt-text);
+  border: 1px solid var(--cfpt-border);
+  border-radius: 10px;
+  padding: 8px 10px;
   font-size: 13px;
   resize: vertical;
 }
-textarea:focus, input:focus { outline: 1px solid #10a37f; }
-.cfpt-radio-row { display: flex; gap: 14px; margin-bottom: 8px; font-size: 13px; }
+textarea:focus, input:focus { outline: 2px solid var(--cfpt-accent); outline-offset: 1px; }
+.cfpt-radio-row { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 8px; font-size: 13px; }
 .cfpt-radio-row label { display: flex; align-items: center; gap: 5px; cursor: pointer; }
 .cfpt-btn {
   display: inline-block;
-  border: none;
-  border-radius: 8px;
+  border: 1px solid var(--cfpt-border);
+  border-radius: 10px;
   padding: 8px 14px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  background: #444654;
-  color: #ececf1;
+  background: var(--cfpt-hover);
+  color: var(--cfpt-text);
   margin-right: 8px;
   margin-top: 6px;
 }
-.cfpt-btn:hover { filter: brightness(1.15); }
-.cfpt-btn-primary { background: #10a37f; color: #fff; }
-.cfpt-btn-danger { background: #7f1d1d; }
+.cfpt-btn:hover { filter: brightness(1.06); }
+.cfpt-btn:focus-visible { outline: 2px solid var(--cfpt-accent); outline-offset: 2px; }
+.cfpt-btn-primary { background: var(--cfpt-accent); color: #fff; border-color: transparent; }
+.cfpt-btn-danger {
+  background: color-mix(in srgb, #dc2626 18%, var(--cfpt-surface));
+  color: #dc2626;
+  border-color: color-mix(in srgb, #dc2626 30%, transparent);
+}
 .cfpt-status-line { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
 .cfpt-spinner {
   width: 12px;
   height: 12px;
-  border: 2px solid #565869;
-  border-top-color: #10a37f;
+  border: 2px solid var(--cfpt-border);
+  border-top-color: var(--cfpt-accent);
   border-radius: 50%;
   animation: cfpt-spin 0.9s linear infinite;
 }
 @keyframes cfpt-spin { to { transform: rotate(360deg); } }
-.cfpt-counters { color: #b4b4bc; font-size: 12px; margin-bottom: 8px; }
+.cfpt-counters { color: var(--cfpt-muted); font-size: 12px; margin-bottom: 8px; }
 .cfpt-log {
-  background: #16171a;
-  border: 1px solid #343541;
-  border-radius: 8px;
+  background: color-mix(in srgb, var(--cfpt-surface) 90%, #000 10%);
+  border: 1px solid var(--cfpt-border);
+  border-radius: 10px;
   padding: 8px;
   font-size: 11px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -135,31 +168,15 @@ textarea:focus, input:focus { outline: 1px solid #10a37f; }
   white-space: pre-wrap;
   word-break: break-word;
 }
-.cfpt-log .warn { color: #fbbf24; }
-.cfpt-log .error { color: #f87171; }
-.cfpt-log .marker { color: #34d399; }
-.cfpt-link { color: #58a6ff; text-decoration: none; }
+.cfpt-log .warn { color: #d97706; }
+.cfpt-log .error { color: #dc2626; }
+.cfpt-log .marker { color: #059669; }
+.cfpt-link { color: #3b82f6; text-decoration: none; }
 .cfpt-link:hover { text-decoration: underline; }
-.cfpt-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.65);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 2147483002;
+@media (max-width: 520px) {
+  .cfpt-dock-title { display: none; }
+  .cfpt-chip { display: none; }
+  .cfpt-body { padding: 12px; }
+  .cfpt-btn { padding-inline: 11px; }
 }
-.cfpt-modal {
-  width: min(440px, 92vw);
-  background: #202123;
-  color: #ececf1;
-  border: 1px solid #444654;
-  border-radius: 16px;
-  padding: 28px;
-  text-align: center;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
-}
-.cfpt-modal .big { font-size: 44px; margin-bottom: 8px; }
-.cfpt-modal h2 { margin: 0 0 8px; font-size: 20px; }
-.cfpt-modal p { color: #b4b4bc; font-size: 13px; margin: 0 0 16px; }
 `;

--- a/tests/panel.test.ts
+++ b/tests/panel.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { newRunState } from "../src/common/state-machine";
+import { Panel, type PanelHooks } from "../src/content/ui/panel";
+
+const panels: Panel[] = [];
+
+function fixture(): void {
+  document.body.innerHTML = `
+    <main id="main">
+      <div id="thread">
+        <div id="thread-bottom">
+          <div data-prompt-textarea-header></div>
+          <form data-type="unified-composer">
+            <div data-composer-surface="true">
+              <div id="prompt-textarea" class="ProseMirror" contenteditable="true"></div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  `;
+}
+
+function makePanel(): Panel {
+  const hooks: PanelHooks = {
+    onEvent: vi.fn(),
+    onNewProject: vi.fn(),
+    getHandoffPrompt: vi.fn(() => "handoff"),
+  };
+  const panel = new Panel(hooks);
+  panels.push(panel);
+  return panel;
+}
+
+function host(): HTMLElement {
+  const element = document.getElementById("cfpt-root");
+  if (!element) throw new Error("embedded Chat FreePT host missing");
+  return element;
+}
+
+beforeEach(() => {
+  fixture();
+});
+
+afterEach(() => {
+  panels.splice(0).forEach((panel) => panel.dispose());
+});
+
+describe("embedded composer panel", () => {
+  it("mounts exactly once in the ChatGPT composer header", () => {
+    makePanel();
+    const header = document.querySelector("[data-prompt-textarea-header]");
+
+    expect(header?.querySelector("#cfpt-root")).toBe(host());
+    expect(document.querySelectorAll("#cfpt-root")).toHaveLength(1);
+    expect(host().dataset["cfptEmbedded"]).toBe("true");
+  });
+
+  it("tracks toggle and rendered status on the light-DOM host", () => {
+    const panel = makePanel();
+    const idle = newRunState("conversation-1", 1);
+
+    panel.render(idle);
+    expect(host().dataset["status"]).toBe("idle");
+    expect(host().dataset["phase"]).toBe("idle");
+    expect(host().dataset["expanded"]).toBe("false");
+
+    panel.toggle();
+    expect(host().dataset["expanded"]).toBe("true");
+
+    panel.render({
+      ...idle,
+      phase: "planning",
+      status: "awaiting_user",
+      pauseReason: "Choose a repository name",
+    });
+    expect(host().dataset["state"]).toBe("attention");
+    expect(host().dataset["status"]).toBe("awaiting_user");
+  });
+
+  it("re-homes the same host when ChatGPT replaces the composer header", async () => {
+    makePanel();
+    const first = document.querySelector("[data-prompt-textarea-header]");
+    const replacement = document.createElement("div");
+    replacement.setAttribute("data-prompt-textarea-header", "");
+    first?.replaceWith(replacement);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(replacement.querySelector("#cfpt-root")).toBe(host());
+    expect(document.querySelectorAll("#cfpt-root")).toHaveLength(1);
+  });
+
+  it("expands the embedded controls for completion instead of creating an overlay", () => {
+    const panel = makePanel();
+    const complete = {
+      ...newRunState("conversation-1", 1),
+      phase: "complete" as const,
+      status: "complete" as const,
+      repo: "owner/project",
+    };
+
+    panel.render(complete);
+    panel.showCompletionModal(complete);
+
+    expect(host().dataset["expanded"]).toBe("true");
+    expect(document.querySelector(".cfpt-modal-backdrop")).toBeNull();
+  });
+});

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -2,31 +2,47 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { healthCheck, query, queryAll, queryLast, resolve } from "../src/content/selectors";
 
 /**
- * Synthetic fixture reflecting chatgpt.com's known structure (composer, send button,
- * message turns). Refresh against the live site when selectors drift — the registry's
- * candidate order encodes today's DOM first.
+ * Synthetic fixture shaped from the current chatgpt.com DOM capture: the thread owns
+ * section turns, the composer is unified, and Chat FreePT mounts in the prompt header.
  */
 const CHATGPT_FIXTURE = `
-  <main>
-    <div role="presentation">
-      <article data-testid="conversation-turn-1">
-        <div data-message-author-role="user" data-message-id="u1">build me a thing</div>
-      </article>
-      <article data-testid="conversation-turn-2">
-        <div data-message-author-role="assistant" data-message-id="a1">
-          <div class="markdown">working on it</div>
-        </div>
-      </article>
-      <article data-testid="conversation-turn-3">
-        <div data-message-author-role="assistant" data-message-id="a2">
-          <div class="markdown">done<pre><code>CHATFREEPT_STATUS: CONTINUE</code></pre></div>
-        </div>
-      </article>
+  <main id="main">
+    <div id="thread">
+      <div data-turn-id-container="request-user-1">
+        <section data-testid="conversation-turn-1" data-turn="user">
+          <div class="user-turn">
+            <div data-message-author-role="user" data-message-id="u1">build me a thing</div>
+          </div>
+        </section>
+      </div>
+      <div data-turn-id-container="request-assistant-1">
+        <section data-testid="conversation-turn-2" data-turn="assistant">
+          <div class="agent-turn">
+            <div data-message-author-role="assistant" data-message-id="a1">
+              <div class="markdown">working on it</div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div data-turn-id-container="request-assistant-2">
+        <section data-testid="conversation-turn-3" data-turn="assistant">
+          <div class="agent-turn">
+            <div data-message-author-role="assistant" data-message-id="a2">
+              <div class="markdown">done<pre><code>CHATFREEPT_STATUS: CONTINUE</code></pre></div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div id="thread-bottom">
+        <div data-prompt-textarea-header></div>
+        <form data-type="unified-composer">
+          <div data-composer-surface="true">
+            <div id="prompt-textarea" class="ProseMirror" contenteditable="true"><p></p></div>
+            <button data-testid="send-button" aria-label="Send prompt"></button>
+          </div>
+        </form>
+      </div>
     </div>
-    <form>
-      <div id="prompt-textarea" class="ProseMirror" contenteditable="true"><p></p></div>
-      <button id="composer-submit-button" data-testid="send-button" aria-label="Send prompt"></button>
-    </form>
   </main>
 `;
 
@@ -35,8 +51,9 @@ beforeEach(() => {
 });
 
 describe("selector registry", () => {
-  it("resolves the primary candidates on the reference fixture", () => {
+  it("resolves primary candidates on the captured ChatGPT structure", () => {
     expect(resolve("composer")?.candidateIndex).toBe(0);
+    expect(resolve("composerHeader")?.candidateIndex).toBe(0);
     expect(resolve("sendButton")?.candidateIndex).toBe(0);
     expect(resolve("conversationRoot")?.candidateIndex).toBe(0);
     expect(resolve("assistantMessage")?.candidateIndex).toBe(0);
@@ -62,18 +79,24 @@ describe("selector registry", () => {
     expect(query("toolIndicator", turn)?.textContent).toBe("GitHub");
   });
 
-  it("falls back down the candidate list", () => {
-    document.getElementById("prompt-textarea")?.removeAttribute("id");
-    const res = resolve("composer");
-    expect(res).not.toBeNull();
-    expect(res?.candidateIndex).toBeGreaterThan(0);
+  it("does not treat an empty-composer Send button absence as unhealthy", () => {
+    document.querySelector('[data-testid="send-button"]')?.remove();
+    expect(query("sendButton")).toBeNull();
+    expect(healthCheck().missing).toEqual([]);
   });
 
-  it("filters text-matched candidates", () => {
-    document.body.innerHTML = `<main><form>
-      <div id="prompt-textarea" contenteditable="true"></div>
-      <button>Cancel</button><button>Send</button>
-    </form></main>`;
+  it("falls back down the composer and composer-header candidate lists", () => {
+    document.getElementById("prompt-textarea")?.removeAttribute("id");
+    document.getElementById("thread-bottom")?.removeAttribute("id");
+
+    expect(resolve("composer")?.candidateIndex).toBeGreaterThan(0);
+    expect(resolve("composerHeader")?.candidateIndex).toBeGreaterThan(0);
+  });
+
+  it("filters text-matched Send candidates", () => {
+    document.querySelector('[data-testid="send-button"]')?.remove();
+    const form = document.querySelector("form");
+    form?.insertAdjacentHTML("beforeend", "<button>Cancel</button><button>Send</button>");
     const res = resolve("sendButton");
     expect(res?.element.textContent).toBe("Send");
   });
@@ -86,19 +109,20 @@ describe("selector registry", () => {
     expect(query("stopButton")).not.toBeNull();
   });
 
-  it("healthCheck passes on the fixture and fails when required targets vanish", () => {
+  it("healthCheck fails only when an automation-required target vanishes", () => {
     expect(healthCheck().missing).toEqual([]);
 
     document.getElementById("prompt-textarea")?.remove();
-    document.querySelectorAll("button").forEach((b) => b.remove());
+    document.querySelectorAll('[contenteditable="true"]').forEach((el) => el.remove());
     const report = healthCheck();
     expect(report.missing).toContain("composer");
-    expect(report.missing).toContain("sendButton");
+    expect(report.missing).not.toContain("sendButton");
+    expect(report.missing).not.toContain("composerHeader");
   });
 
-  it("healthCheck reports degradation when primaries drift", () => {
+  it("healthCheck reports degradation when the primary composer drifts", () => {
     document.getElementById("prompt-textarea")?.removeAttribute("id");
     const report = healthCheck();
-    expect(report.degraded.some((d) => d.id === "composer")).toBe(true);
+    expect(report.degraded.some((item) => item.id === "composer")).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #28

## Result
Chat FreePT now lives inside ChatGPT instead of floating over it. The fixed bottom-right FAB/panel is replaced by a compact, collapsible control dock mounted directly in ChatGPT's prompt-header slot above the unified composer. The dock always exposes phase/status, expands upward to the existing project and orchestration controls, follows light/dark/custom ChatGPT theme tokens, and re-homes the same shadow host when ChatGPT replaces the composer subtree.

## Implementation
Added a centralized `composerHeader` target using the captured `[data-prompt-textarea-header]` structure, refreshed current thread/message selectors, and scoped the preferred conversation root to `#thread`. `sendButton` is no longer globally required because the captured healthy empty composer renders Voice rather than Send; `clickSend()` still independently waits for the real Send control after prompt insertion. `Panel` now mounts one closed-shadow `#cfpt-root` in the composer header, observes child-list replacement across SPA hydration/navigation, and reuses that host without duplicates. The old page-wide completion modal now simply expands the embedded completion controls. Styling inherits ChatGPT composer/text/border/theme variables with safe browser fallbacks and responsive behavior.

## Verification
Selector fixtures were rebuilt around the supplied current ChatGPT DOM: `main#main`, `#thread`, section turns with `data-turn`, `data-message-author-role`/`data-message-id`, `#thread-bottom`, `[data-prompt-textarea-header]`, `form[data-type="unified-composer"]`, `[data-composer-surface]`, and `#prompt-textarea`. Tests cover healthy empty-composer behavior without Send, primary/fallback selector resolution, embedded mount uniqueness, status/toggle state, re-homing after composer-header replacement, and embedded completion expansion. Hosted metadata, fast deterministic quality, PR test/build, dependency audit, and security/workflow policy gates are required before merge.

## Risk
Moderate DOM-integration risk localized to the ChatGPT host boundary and control-surface presentation. The new mount target comes directly from two current saved ChatGPT pages, host selectors remain centralized, the shadow root stays closed, and no private API, network interception, React internals, credentials, runtime dependency, orchestration strategy, or storage schema is introduced.

## Remaining work
After merge, load the packaged dev build on live ChatGPT and verify the typed-prompt Send transition plus active-stream Stop affordance. If either runtime-only control differs from the current selector fallbacks, capture the Elements DOM for that state and harden only the selector registry in a follow-up slice.