### PR TITLE
Preserve installable extension packages from PR CI

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -118,6 +118,13 @@ jobs:
           cache-dependency-path: ci/requirements-ci.txt
       - run: ./scripts/bootstrap --ci
       - run: ./ci/run pr
+      - name: Upload installable extension package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: chat-freept-pr-${{ github.event.pull_request.number || github.sha }}
+          path: artifacts/chat-freept.zip
+          if-no-files-found: error
+          retention-days: 14
       - name: Upload PR gate report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
Fixes #30

## Result
Every validated `dev` pull request now preserves the installable Chat FreePT ZIP that the existing PR gate already builds, making browser smoke testing possible before production promotion.

## Implementation
Added one `actions/upload-artifact` step to the existing `PR test/build gates` job immediately after `./ci/run pr`. It uploads the already-generated `artifacts/chat-freept.zip`, fails if that package is absent, and retains it for 14 days. The existing CI-report artifact remains separate and unchanged.

## Verification
This PR's own hosted run must prove the complete path end to end: the existing PR gate builds/tests/packages the extension, the new step successfully uploads that exact package, metadata recognizes the required `risk:ci` label, and security/workflow policy remains green. No second package path is introduced.

## Risk
Low and CI-only. This changes `.github/workflows/ci-pr.yml`, so Issue #30 and this PR carry `risk:ci`. It does not change permissions, credentials, dependencies, release behavior, runtime extension code, publishing, or merge authority.

## Remaining work
After merge, use the generated package from this PR to live-test the embedded Chat FreePT composer integration on chatgpt.com. Promote the DOM change to production only after typed-prompt Send and active-stream Stop behavior are confirmed.