### PR TITLE
Use airplane composer launcher with first-run onboarding

### DIFF
--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -7,6 +7,7 @@
 export type TargetId =
   | "composer"
   | "composerHeader"
+  | "composerSurface"
   | "sendButton"
   | "stopButton"
   | "assistantMessage"
@@ -44,6 +45,15 @@ const REGISTRY: Record<TargetId, Target> = {
       { css: "#thread-bottom [data-prompt-textarea-header]" },
       { css: "main [data-prompt-textarea-header]" },
       { css: "[data-prompt-textarea-header]" },
+    ],
+  },
+  composerSurface: {
+    required: false,
+    candidates: [
+      { css: '#thread-bottom form[data-type="unified-composer"] [data-composer-surface="true"]' },
+      { css: 'form[data-type="unified-composer"] [data-composer-surface="true"]' },
+      { css: '[data-composer-surface="true"]' },
+      { css: 'form[data-type="unified-composer"]' },
     ],
   },
   sendButton: {

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -532,7 +532,9 @@ export class Panel {
 
   private refValue(ref: string): string {
     const el = this.panelEl.querySelector(`[data-ref="${ref}"]`) as
-      HTMLTextAreaElement | HTMLInputElement | null;
+      | HTMLTextAreaElement
+      | HTMLInputElement
+      | null;
     return el?.value ?? "";
   }
 

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -148,10 +148,7 @@ export class Panel {
 
     this.shadow.addEventListener("click", (event) => this.onClick(event));
     this.setupBackdropEl.addEventListener("keydown", (event) => {
-      if (
-        event.key === "Escape" &&
-        !this.setupBackdropEl.classList.contains("cfpt-hidden")
-      ) {
+      if (event.key === "Escape" && !this.setupBackdropEl.classList.contains("cfpt-hidden")) {
         void this.acknowledgeSetup();
       }
     });
@@ -167,10 +164,7 @@ export class Panel {
     this.panelEl.classList.toggle("cfpt-hidden", !show);
     this.host.dataset["expanded"] = String(show);
     this.launcher.setAttribute("aria-expanded", String(show));
-    this.launcher.setAttribute(
-      "aria-label",
-      show ? "Close Chat FreePT" : "Open Chat FreePT",
-    );
+    this.launcher.setAttribute("aria-label", show ? "Close Chat FreePT" : "Open Chat FreePT");
   }
 
   render(state: RunState, passive = false): void {
@@ -179,9 +173,7 @@ export class Panel {
     this.host.dataset["status"] = state.status;
     this.host.dataset["phase"] = state.phase;
     this.launcher.dataset["state"] = visualState;
-    const status = passive
-      ? "Active in another tab"
-      : (STATUS_LABEL[state.status] ?? state.status);
+    const status = passive ? "Active in another tab" : (STATUS_LABEL[state.status] ?? state.status);
     this.launcher.title = `Chat FreePT · ${phaseLabel(state.phase)} · ${status}`;
 
     const viewKey = `${state.phase}|${state.status}|${state.pauseReason ?? ""}|${passive}`;

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -9,6 +9,17 @@ export interface PanelHooks {
   getHandoffPrompt: () => string;
 }
 
+interface OnboardingState {
+  launcherTipSuppressed: boolean;
+  setupShown: boolean;
+}
+
+const ONBOARDING_KEY = "cfpt:onboarding:v1";
+const DEFAULT_ONBOARDING: OnboardingState = {
+  launcherTipSuppressed: false,
+  setupShown: false,
+};
+
 const STATUS_LABEL: Record<string, string> = {
   idle: "Idle",
   inserting: "Writing prompt…",
@@ -27,29 +38,43 @@ function esc(text: string): string {
   return div.innerHTML;
 }
 
+function normalizeOnboarding(value: unknown): OnboardingState {
+  if (!value || typeof value !== "object") return { ...DEFAULT_ONBOARDING };
+  const candidate = value as Partial<OnboardingState>;
+  return {
+    launcherTipSuppressed: candidate.launcherTipSuppressed === true,
+    setupShown: candidate.setupShown === true,
+  };
+}
+
 /**
- * Native-style Chat FreePT controls embedded in ChatGPT's composer header slot. A closed
- * shadow root keeps both style systems isolated, while a subtree observer re-homes the
+ * Compact Chat FreePT controls mounted directly inside ChatGPT's composer surface. The
+ * airplane launcher is always present; the full controls float above it only while open.
+ * A closed shadow root isolates both style systems while a subtree observer re-homes the
  * single host when ChatGPT replaces its composer during SPA navigation or hydration.
  */
 export class Panel {
   private readonly host: HTMLDivElement;
   private readonly shadow: ShadowRoot;
-  private readonly dock: HTMLButtonElement;
-  private readonly dockPhase: HTMLSpanElement;
-  private readonly dockStatus: HTMLSpanElement;
-  private readonly chevron: HTMLSpanElement;
+  private readonly launcher: HTMLButtonElement;
   private readonly panelEl: HTMLDivElement;
+  private readonly launcherTipEl: HTMLDivElement;
+  private readonly setupBackdropEl: HTMLDivElement;
   private readonly mountObserver: MutationObserver;
   private lastViewKey = "";
   private stopArmed = false;
   private mountQueued = false;
+  private disposed = false;
+  private onboarding = { ...DEFAULT_ONBOARDING };
 
   constructor(private readonly hooks: PanelHooks) {
     this.host = document.createElement("div");
     this.host.id = "cfpt-root";
     this.host.dataset["cfptEmbedded"] = "true";
+    this.host.dataset["cfptLauncher"] = "airplane";
     this.host.dataset["expanded"] = "false";
+    this.host.dataset["onboarding"] = "loading";
+    this.host.dataset["highlighted"] = "false";
     this.shadow = this.host.attachShadow({ mode: "closed" });
 
     const style = document.createElement("style");
@@ -58,52 +83,98 @@ export class Panel {
 
     this.panelEl = document.createElement("div");
     this.panelEl.className = "cfpt-panel cfpt-hidden";
-    this.panelEl.addEventListener("click", (event) => this.onClick(event));
     this.shadow.appendChild(this.panelEl);
 
-    this.dock = document.createElement("button");
-    this.dock.type = "button";
-    this.dock.className = "cfpt-dock";
-    this.dock.title = "Chat FreePT controls";
-    this.dock.setAttribute("aria-expanded", "false");
-    this.dock.innerHTML = `
-      <span class="cfpt-mark" aria-hidden="true">FP</span>
-      <span class="cfpt-dock-title">Chat FreePT</span>
-      <span class="cfpt-chip" data-phase="idle">Ready</span>
-      <span class="cfpt-dock-status">Idle</span>
-      <span class="cfpt-chevron" aria-hidden="true">▴</span>
+    this.launcher = document.createElement("button");
+    this.launcher.type = "button";
+    this.launcher.className = "cfpt-launcher";
+    this.launcher.title = "Open Chat FreePT";
+    this.launcher.setAttribute("aria-label", "Open Chat FreePT");
+    this.launcher.setAttribute("aria-expanded", "false");
+    this.launcher.innerHTML = `
+      <svg class="cfpt-airplane" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M12 2.5c-.8 0-1.4.6-1.4 1.4v5.3L3 13.8v2l7.6-2.4v4.2l-2.3 1.7v1.4l3.7-1.1 3.7 1.1v-1.4l-2.3-1.7v-4.2l7.6 2.4v-2l-7.6-4.6V3.9c0-.8-.6-1.4-1.4-1.4Z"></path>
+      </svg>
     `;
-    this.dock.addEventListener("click", () => this.toggle());
-    this.shadow.appendChild(this.dock);
+    this.launcher.addEventListener("click", () => {
+      if (!this.launcherTipEl.classList.contains("cfpt-hidden")) {
+        void this.acknowledgeLauncherTip(this.tipCheckboxChecked());
+      }
+      this.toggle();
+    });
+    this.shadow.appendChild(this.launcher);
 
-    this.dockPhase = this.requiredShadowElement<HTMLSpanElement>(".cfpt-chip");
-    this.dockStatus = this.requiredShadowElement<HTMLSpanElement>(".cfpt-dock-status");
-    this.chevron = this.requiredShadowElement<HTMLSpanElement>(".cfpt-chevron");
+    this.launcherTipEl = document.createElement("div");
+    this.launcherTipEl.className = "cfpt-onboarding-toast cfpt-hidden";
+    this.launcherTipEl.setAttribute("role", "status");
+    this.launcherTipEl.innerHTML = `
+      <div class="cfpt-toast-arrow" aria-hidden="true"></div>
+      <button class="cfpt-icon-close" type="button" data-action="tip-continue" aria-label="Dismiss launcher tip">×</button>
+      <strong>Chat FreePT lives here</strong>
+      <p>Use the airplane inside the ChatGPT input whenever you want to open Chat FreePT.</p>
+      <label class="cfpt-check-row">
+        <input type="checkbox" data-ref="suppress-launcher-tip" />
+        <span>Don't show this tip again</span>
+      </label>
+      <button class="cfpt-btn cfpt-btn-primary cfpt-toast-continue" type="button" data-action="tip-continue">Continue</button>
+    `;
+    this.shadow.appendChild(this.launcherTipEl);
+
+    this.setupBackdropEl = document.createElement("div");
+    this.setupBackdropEl.className = "cfpt-setup-backdrop cfpt-hidden";
+    this.setupBackdropEl.setAttribute("role", "presentation");
+    this.setupBackdropEl.innerHTML = `
+      <section class="cfpt-setup-card" role="dialog" aria-modal="true" aria-labelledby="cfpt-setup-title">
+        <button class="cfpt-icon-close" type="button" data-action="setup-done" aria-label="Close setup instructions">×</button>
+        <div class="cfpt-setup-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2.5c-.8 0-1.4.6-1.4 1.4v5.3L3 13.8v2l7.6-2.4v4.2l-2.3 1.7v1.4l3.7-1.1 3.7 1.1v-1.4l-2.3-1.7v-4.2l7.6 2.4v-2l-7.6-4.6V3.9c0-.8-.6-1.4-1.4-1.4Z"></path></svg>
+        </div>
+        <h2 id="cfpt-setup-title">Set up GitHub access once</h2>
+        <p class="cfpt-setup-lead">For fully autonomous new-repository work, ChatGPT needs a GitHub MCP app with repository and workflow write access.</p>
+        <ol class="cfpt-setup-steps">
+          <li>Open <strong>Settings → Security and login → Developer mode</strong> and turn it on.</li>
+          <li>Open ChatGPT Plugins, select <strong>+</strong>, and add <code>https://api.githubcopilot.com/mcp/</code> using OAuth.</li>
+          <li>In the conversation's Plus menu, choose <strong>Developer mode</strong> and select that GitHub app.</li>
+          <li>Authorize the repository and workflow write access Chat FreePT's preflight requests.</li>
+        </ol>
+        <p class="cfpt-setup-footnote">Existing repositories may work with another GitHub connector if it passes Chat FreePT's capability preflight. Chat FreePT never receives your GitHub credentials.</p>
+        <div class="cfpt-setup-actions">
+          <a class="cfpt-btn" href="https://chatgpt.com/plugins" target="_blank" rel="noreferrer noopener">Open ChatGPT Plugins</a>
+          <button class="cfpt-btn cfpt-btn-primary" type="button" data-action="setup-done">Got it</button>
+        </div>
+      </section>
+    `;
+    this.shadow.appendChild(this.setupBackdropEl);
+
+    this.shadow.addEventListener("click", (event) => this.onClick(event));
+    this.shadow.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && !this.setupBackdropEl.classList.contains("cfpt-hidden")) {
+        void this.acknowledgeSetup();
+      }
+    });
 
     this.mountObserver = new MutationObserver(() => this.scheduleMount());
     this.mountObserver.observe(document.documentElement, { childList: true, subtree: true });
     this.mount();
+    void this.initOnboarding();
   }
 
   toggle(force?: boolean): void {
     const show = force ?? this.panelEl.classList.contains("cfpt-hidden");
     this.panelEl.classList.toggle("cfpt-hidden", !show);
     this.host.dataset["expanded"] = String(show);
-    this.dock.setAttribute("aria-expanded", String(show));
-    this.chevron.textContent = show ? "▾" : "▴";
+    this.launcher.setAttribute("aria-expanded", String(show));
+    this.launcher.setAttribute("aria-label", show ? "Close Chat FreePT" : "Open Chat FreePT");
   }
 
   render(state: RunState, passive = false): void {
-    const visualState = passive ? "attention" : dockState(state);
+    const visualState = passive ? "attention" : launcherState(state);
     this.host.dataset["state"] = visualState;
     this.host.dataset["status"] = state.status;
     this.host.dataset["phase"] = state.phase;
-    this.dock.dataset["state"] = visualState;
-    this.dockPhase.dataset["phase"] = state.phase;
-    this.dockPhase.textContent = phaseLabel(state.phase);
-    this.dockStatus.textContent = passive
-      ? "Active in another tab"
-      : (STATUS_LABEL[state.status] ?? state.status);
+    this.launcher.dataset["state"] = visualState;
+    const status = passive ? "Active in another tab" : (STATUS_LABEL[state.status] ?? state.status);
+    this.launcher.title = `Chat FreePT · ${phaseLabel(state.phase)} · ${status}`;
 
     const viewKey = `${state.phase}|${state.status}|${state.pauseReason ?? ""}|${passive}`;
     if (viewKey !== this.lastViewKey) {
@@ -116,14 +187,85 @@ export class Panel {
   }
 
   dispose(): void {
+    this.disposed = true;
     this.mountObserver.disconnect();
     this.host.remove();
   }
 
-  private requiredShadowElement<T extends Element>(selector: string): T {
-    const element = this.shadow.querySelector(selector);
-    if (!element) throw new Error(`Chat FreePT shadow element missing: ${selector}`);
-    return element as T;
+  async acknowledgeLauncherTip(suppress: boolean): Promise<void> {
+    this.launcherTipEl.classList.add("cfpt-hidden");
+    this.host.dataset["highlighted"] = "false";
+    if (suppress) this.onboarding.launcherTipSuppressed = true;
+    await this.persistOnboarding();
+    if (!this.onboarding.setupShown) {
+      this.showSetupModal();
+    } else {
+      this.host.dataset["onboarding"] = "done";
+    }
+  }
+
+  async acknowledgeSetup(): Promise<void> {
+    this.setupBackdropEl.classList.add("cfpt-hidden");
+    this.onboarding.setupShown = true;
+    this.host.dataset["onboarding"] = "done";
+    await this.persistOnboarding();
+  }
+
+  showCompletionModal(_state: RunState): void {
+    this.toggle(true);
+  }
+
+  private async initOnboarding(): Promise<void> {
+    try {
+      const found = await chrome.storage.local.get(ONBOARDING_KEY);
+      this.onboarding = normalizeOnboarding(found[ONBOARDING_KEY]);
+    } catch {
+      this.onboarding = { ...DEFAULT_ONBOARDING };
+    }
+    if (this.disposed) return;
+
+    if (!this.onboarding.launcherTipSuppressed) {
+      this.showLauncherTip();
+      return;
+    }
+    if (!this.onboarding.setupShown) {
+      this.showSetupModal();
+      return;
+    }
+    this.host.dataset["onboarding"] = "done";
+  }
+
+  private async persistOnboarding(): Promise<void> {
+    try {
+      await chrome.storage.local.set({ [ONBOARDING_KEY]: this.onboarding });
+    } catch {
+      // Onboarding persistence must never prevent the extension controls from operating.
+    }
+  }
+
+  private showLauncherTip(): void {
+    this.setupBackdropEl.classList.add("cfpt-hidden");
+    this.launcherTipEl.classList.remove("cfpt-hidden");
+    this.host.dataset["onboarding"] = "tip";
+    this.host.dataset["highlighted"] = "true";
+  }
+
+  private showSetupModal(): void {
+    this.launcherTipEl.classList.add("cfpt-hidden");
+    this.host.dataset["highlighted"] = "false";
+    this.setupBackdropEl.classList.remove("cfpt-hidden");
+    this.host.dataset["onboarding"] = "setup";
+    queueMicrotask(() => {
+      const button = this.setupBackdropEl.querySelector<HTMLButtonElement>('[data-action="setup-done"]');
+      button?.focus();
+    });
+  }
+
+  private tipCheckboxChecked(): boolean {
+    const input = this.launcherTipEl.querySelector<HTMLInputElement>(
+      '[data-ref="suppress-launcher-tip"]',
+    );
+    return input?.checked === true;
   }
 
   private scheduleMount(): void {
@@ -136,7 +278,7 @@ export class Panel {
   }
 
   private mount(): void {
-    const anchor = query("composerHeader");
+    const anchor = query("composerSurface") ?? query("composerHeader");
     if (!anchor || this.host.parentElement === anchor) return;
     anchor.appendChild(this.host);
   }
@@ -338,6 +480,12 @@ export class Panel {
       case "copyhandoff":
         this.copyHandoff(target);
         break;
+      case "tip-continue":
+        void this.acknowledgeLauncherTip(this.tipCheckboxChecked());
+        break;
+      case "setup-done":
+        void this.acknowledgeSetup();
+        break;
     }
   }
 
@@ -380,7 +528,9 @@ export class Panel {
 
   private refValue(ref: string): string {
     const el = this.panelEl.querySelector(`[data-ref="${ref}"]`) as
-      HTMLTextAreaElement | HTMLInputElement | null;
+      | HTMLTextAreaElement
+      | HTMLInputElement
+      | null;
     return el?.value ?? "";
   }
 
@@ -389,11 +539,6 @@ export class Panel {
       `input[name="${name}"]:checked`,
     ) as HTMLInputElement | null;
     return el?.value ?? "";
-  }
-
-  showCompletionModal(_state: RunState): void {
-    // Completion stays embedded instead of creating a page-wide overlay.
-    this.toggle(true);
   }
 }
 
@@ -416,7 +561,7 @@ function phaseLabel(phase: string): string {
   }
 }
 
-function dockState(state: RunState): string {
+function launcherState(state: RunState): string {
   if (state.status === "error") return "error";
   if (state.status === "awaiting_user") return "attention";
   if (state.status === "complete") return "done";

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -147,7 +147,7 @@ export class Panel {
     this.shadow.appendChild(this.setupBackdropEl);
 
     this.shadow.addEventListener("click", (event) => this.onClick(event));
-    this.shadow.addEventListener("keydown", (event) => {
+    this.setupBackdropEl.addEventListener("keydown", (event) => {
       if (event.key === "Escape" && !this.setupBackdropEl.classList.contains("cfpt-hidden")) {
         void this.acknowledgeSetup();
       }
@@ -173,7 +173,9 @@ export class Panel {
     this.host.dataset["status"] = state.status;
     this.host.dataset["phase"] = state.phase;
     this.launcher.dataset["state"] = visualState;
-    const status = passive ? "Active in another tab" : (STATUS_LABEL[state.status] ?? state.status);
+    const status = passive
+      ? "Active in another tab"
+      : (STATUS_LABEL[state.status] ?? state.status);
     this.launcher.title = `Chat FreePT · ${phaseLabel(state.phase)} · ${status}`;
 
     const viewKey = `${state.phase}|${state.status}|${state.pauseReason ?? ""}|${passive}`;
@@ -256,7 +258,9 @@ export class Panel {
     this.setupBackdropEl.classList.remove("cfpt-hidden");
     this.host.dataset["onboarding"] = "setup";
     queueMicrotask(() => {
-      const button = this.setupBackdropEl.querySelector<HTMLButtonElement>('[data-action="setup-done"]');
+      const button = this.setupBackdropEl.querySelector<HTMLButtonElement>(
+        '[data-action="setup-done"]',
+      );
       button?.focus();
     });
   }
@@ -528,9 +532,7 @@ export class Panel {
 
   private refValue(ref: string): string {
     const el = this.panelEl.querySelector(`[data-ref="${ref}"]`) as
-      | HTMLTextAreaElement
-      | HTMLInputElement
-      | null;
+      HTMLTextAreaElement | HTMLInputElement | null;
     return el?.value ?? "";
   }
 

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -148,7 +148,10 @@ export class Panel {
 
     this.shadow.addEventListener("click", (event) => this.onClick(event));
     this.setupBackdropEl.addEventListener("keydown", (event) => {
-      if (event.key === "Escape" && !this.setupBackdropEl.classList.contains("cfpt-hidden")) {
+      if (
+        event.key === "Escape" &&
+        !this.setupBackdropEl.classList.contains("cfpt-hidden")
+      ) {
         void this.acknowledgeSetup();
       }
     });
@@ -164,7 +167,10 @@ export class Panel {
     this.panelEl.classList.toggle("cfpt-hidden", !show);
     this.host.dataset["expanded"] = String(show);
     this.launcher.setAttribute("aria-expanded", String(show));
-    this.launcher.setAttribute("aria-label", show ? "Close Chat FreePT" : "Open Chat FreePT");
+    this.launcher.setAttribute(
+      "aria-label",
+      show ? "Close Chat FreePT" : "Open Chat FreePT",
+    );
   }
 
   render(state: RunState, passive = false): void {

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -532,9 +532,7 @@ export class Panel {
 
   private refValue(ref: string): string {
     const el = this.panelEl.querySelector(`[data-ref="${ref}"]`) as
-      | HTMLTextAreaElement
-      | HTMLInputElement
-      | null;
+      HTMLTextAreaElement | HTMLInputElement | null;
     return el?.value ?? "";
   }
 

--- a/src/content/ui/styles.ts
+++ b/src/content/ui/styles.ts
@@ -1,9 +1,14 @@
 export const PANEL_CSS = `
 :host {
   all: initial;
+  position: absolute;
+  inset-inline-end: 52px;
+  bottom: 8px;
+  width: 34px;
+  height: 34px;
   display: block;
-  width: 100%;
   pointer-events: none;
+  z-index: 2147482000;
   color-scheme: inherit;
   --cfpt-surface: var(--composer-surface-primary, Canvas);
   --cfpt-text: var(--token-text-primary, CanvasText);
@@ -17,86 +22,77 @@ export const PANEL_CSS = `
   font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
 button, textarea, input { font: inherit; }
-.cfpt-dock {
+.cfpt-hidden { display: none !important; }
+.cfpt-launcher {
   pointer-events: auto;
-  width: 100%;
-  min-height: 38px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  border: 1px solid var(--cfpt-border);
-  border-radius: 18px;
-  padding: 6px 10px;
-  background: var(--cfpt-surface);
-  color: var(--cfpt-text);
-  cursor: pointer;
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
-  text-align: start;
-}
-.cfpt-dock:hover { background: var(--cfpt-hover); }
-.cfpt-dock:focus-visible { outline: 2px solid var(--cfpt-accent); outline-offset: 2px; }
-.cfpt-mark {
+  width: 34px;
+  height: 34px;
   display: grid;
   place-items: center;
-  width: 24px;
-  height: 24px;
-  flex: 0 0 24px;
-  border-radius: 8px;
-  background: var(--cfpt-accent);
-  color: #fff;
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: -0.2px;
-}
-.cfpt-dock[data-state="attention"] .cfpt-mark { background: #d97706; }
-.cfpt-dock[data-state="error"] .cfpt-mark { background: #dc2626; }
-.cfpt-dock[data-state="done"] .cfpt-mark { background: #2563eb; }
-.cfpt-dock[data-state="run"] .cfpt-mark { animation: cfpt-pulse 1.6s ease-in-out infinite; }
-@keyframes cfpt-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--cfpt-accent) 45%, transparent); }
-  50% { box-shadow: 0 0 0 7px transparent; }
-}
-.cfpt-dock-title { font-size: 13px; font-weight: 650; white-space: nowrap; }
-.cfpt-dock-status {
-  min-width: 0;
-  flex: 1;
-  color: var(--cfpt-muted);
-  font-size: 12px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.cfpt-chip {
-  flex: 0 0 auto;
-  font-size: 10px;
-  font-weight: 650;
-  padding: 2px 7px;
+  border: 0;
   border-radius: 999px;
-  background: var(--cfpt-hover);
+  padding: 0;
+  background: transparent;
   color: var(--cfpt-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.35px;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
 }
-.cfpt-chip[data-phase="planning"] { color: #0891b2; }
-.cfpt-chip[data-phase="plan_ready"] { color: #ca8a04; }
-.cfpt-chip[data-phase="developing"] { color: #16a34a; }
-.cfpt-chip[data-phase="complete"] { color: #2563eb; }
-.cfpt-chevron { flex: 0 0 auto; color: var(--cfpt-muted); font-size: 11px; }
+.cfpt-launcher:hover {
+  background: var(--cfpt-hover);
+  color: var(--cfpt-text);
+}
+.cfpt-launcher:active { transform: scale(0.95); }
+.cfpt-launcher:focus-visible {
+  outline: 2px solid var(--cfpt-accent);
+  outline-offset: 2px;
+}
+.cfpt-airplane {
+  width: 18px;
+  height: 18px;
+  display: block;
+  fill: currentColor;
+}
+.cfpt-launcher[data-state="run"] {
+  color: var(--cfpt-accent);
+  animation: cfpt-launcher-pulse 1.6s ease-in-out infinite;
+}
+.cfpt-launcher[data-state="attention"] { color: #d97706; }
+.cfpt-launcher[data-state="error"] { color: #dc2626; }
+.cfpt-launcher[data-state="done"] { color: #2563eb; }
+:host([data-highlighted="true"]) .cfpt-launcher {
+  color: var(--cfpt-accent);
+  animation: cfpt-onboarding-pulse 1.15s ease-in-out infinite;
+}
+@keyframes cfpt-launcher-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--cfpt-accent) 35%, transparent); }
+  50% { box-shadow: 0 0 0 6px transparent; }
+}
+@keyframes cfpt-onboarding-pulse {
+  0%, 100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--cfpt-accent) 28%, transparent);
+  }
+  50% {
+    transform: scale(1.08);
+    box-shadow: 0 0 0 8px color-mix(in srgb, var(--cfpt-accent) 8%, transparent);
+  }
+}
 .cfpt-panel {
   pointer-events: auto;
-  width: 100%;
-  max-height: min(52vh, 520px);
+  position: absolute;
+  inset-inline-end: 0;
+  bottom: 44px;
+  width: min(390px, calc(100vw - 24px));
+  max-height: min(62vh, 560px);
   display: flex;
   flex-direction: column;
-  margin-bottom: 8px;
   background: var(--cfpt-surface);
   color: var(--cfpt-text);
   border: 1px solid var(--cfpt-border);
   border-radius: 18px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.2);
   overflow: hidden;
 }
-.cfpt-panel.cfpt-hidden { display: none; }
 .cfpt-body { padding: 14px; overflow-y: auto; font-size: 13px; line-height: 1.45; }
 .cfpt-body h3 { margin: 0 0 8px; color: var(--cfpt-text); font-size: 13px; }
 .cfpt-warn {
@@ -125,17 +121,21 @@ textarea:focus, input:focus { outline: 2px solid var(--cfpt-accent); outline-off
 .cfpt-radio-row { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 8px; font-size: 13px; }
 .cfpt-radio-row label { display: flex; align-items: center; gap: 5px; cursor: pointer; }
 .cfpt-btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid var(--cfpt-border);
   border-radius: 10px;
   padding: 8px 14px;
   font-size: 13px;
   font-weight: 600;
+  line-height: 1.2;
   cursor: pointer;
   background: var(--cfpt-hover);
   color: var(--cfpt-text);
   margin-right: 8px;
   margin-top: 6px;
+  text-decoration: none;
 }
 .cfpt-btn:hover { filter: brightness(1.06); }
 .cfpt-btn:focus-visible { outline: 2px solid var(--cfpt-accent); outline-offset: 2px; }
@@ -173,10 +173,122 @@ textarea:focus, input:focus { outline: 2px solid var(--cfpt-accent); outline-off
 .cfpt-log .marker { color: #059669; }
 .cfpt-link { color: #3b82f6; text-decoration: none; }
 .cfpt-link:hover { text-decoration: underline; }
+.cfpt-onboarding-toast {
+  pointer-events: auto;
+  position: absolute;
+  inset-inline-end: -4px;
+  bottom: 48px;
+  width: min(300px, calc(100vw - 24px));
+  padding: 13px;
+  padding-top: 15px;
+  border: 1px solid var(--cfpt-border);
+  border-radius: 14px;
+  background: var(--cfpt-surface);
+  color: var(--cfpt-text);
+  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.2);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.cfpt-onboarding-toast strong { display: block; padding-right: 22px; font-size: 13px; }
+.cfpt-onboarding-toast p { margin: 6px 0 10px; color: var(--cfpt-muted); }
+.cfpt-toast-arrow {
+  position: absolute;
+  inset-inline-end: 15px;
+  bottom: -6px;
+  width: 11px;
+  height: 11px;
+  background: var(--cfpt-surface);
+  border-right: 1px solid var(--cfpt-border);
+  border-bottom: 1px solid var(--cfpt-border);
+  transform: rotate(45deg);
+}
+.cfpt-icon-close {
+  position: absolute;
+  top: 7px;
+  inset-inline-end: 8px;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--cfpt-muted);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+.cfpt-icon-close:hover { background: var(--cfpt-hover); color: var(--cfpt-text); }
+.cfpt-check-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--cfpt-muted);
+  cursor: pointer;
+}
+.cfpt-check-row input { margin: 0; }
+.cfpt-toast-continue { margin-top: 10px; margin-right: 0; }
+.cfpt-setup-backdrop {
+  pointer-events: auto;
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  background: rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 2147483600;
+}
+.cfpt-setup-card {
+  position: relative;
+  width: min(440px, calc(100vw - 28px));
+  max-height: min(78vh, 620px);
+  overflow-y: auto;
+  padding: 20px;
+  border: 1px solid var(--cfpt-border);
+  border-radius: 18px;
+  background: var(--cfpt-surface);
+  color: var(--cfpt-text);
+  box-shadow: 0 24px 72px rgba(0, 0, 0, 0.28);
+}
+.cfpt-setup-icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 10px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--cfpt-accent) 14%, var(--cfpt-surface));
+  color: var(--cfpt-accent);
+}
+.cfpt-setup-icon svg { width: 19px; height: 19px; fill: currentColor; }
+.cfpt-setup-card h2 { margin: 0 30px 8px 0; font-size: 18px; line-height: 1.25; }
+.cfpt-setup-lead { margin: 0 0 12px; color: var(--cfpt-muted); font-size: 13px; line-height: 1.45; }
+.cfpt-setup-steps { margin: 0; padding-left: 20px; font-size: 13px; line-height: 1.5; }
+.cfpt-setup-steps li + li { margin-top: 7px; }
+.cfpt-setup-steps code {
+  padding: 1px 4px;
+  border-radius: 5px;
+  background: var(--cfpt-hover);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+.cfpt-setup-footnote { margin: 12px 0 0; color: var(--cfpt-muted); font-size: 11px; line-height: 1.45; }
+.cfpt-setup-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+.cfpt-setup-actions .cfpt-btn { margin: 0; }
 @media (max-width: 520px) {
-  .cfpt-dock-title { display: none; }
-  .cfpt-chip { display: none; }
+  :host { inset-inline-end: 48px; bottom: 7px; }
+  .cfpt-panel { width: min(350px, calc(100vw - 16px)); bottom: 42px; }
   .cfpt-body { padding: 12px; }
   .cfpt-btn { padding-inline: 11px; }
+  .cfpt-onboarding-toast { width: min(286px, calc(100vw - 16px)); }
+  .cfpt-setup-card { padding: 17px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cfpt-launcher,
+  :host([data-highlighted="true"]) .cfpt-launcher,
+  .cfpt-spinner { animation: none; transition: none; }
 }
 `;

--- a/tests/panel.test.ts
+++ b/tests/panel.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { newRunState } from "../src/common/state-machine";
 import { Panel, type PanelHooks } from "../src/content/ui/panel";
+import { PANEL_CSS } from "../src/content/ui/styles";
+import { installChromeMock } from "./chrome-mock";
 
 const panels: Panel[] = [];
+let stores: ReturnType<typeof installChromeMock>;
 
 function fixture(): void {
   document.body.innerHTML = `
@@ -38,7 +41,12 @@ function host(): HTMLElement {
   return element;
 }
 
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 beforeEach(() => {
+  stores = installChromeMock();
   fixture();
 });
 
@@ -46,14 +54,23 @@ afterEach(() => {
   panels.splice(0).forEach((panel) => panel.dispose());
 });
 
-describe("embedded composer panel", () => {
-  it("mounts exactly once in the ChatGPT composer header", () => {
+describe("composer airplane launcher", () => {
+  it("mounts exactly once inside the ChatGPT composer surface", () => {
     makePanel();
+    const surface = document.querySelector('[data-composer-surface="true"]');
     const header = document.querySelector("[data-prompt-textarea-header]");
 
-    expect(header?.querySelector("#cfpt-root")).toBe(host());
+    expect(surface?.querySelector("#cfpt-root")).toBe(host());
+    expect(header?.querySelector("#cfpt-root")).toBeNull();
     expect(document.querySelectorAll("#cfpt-root")).toHaveLength(1);
     expect(host().dataset["cfptEmbedded"]).toBe("true");
+    expect(host().dataset["cfptLauncher"]).toBe("airplane");
+  });
+
+  it("uses a compact launcher instead of the old full-width dock", () => {
+    expect(PANEL_CSS).toContain(".cfpt-launcher");
+    expect(PANEL_CSS).toContain(".cfpt-airplane");
+    expect(PANEL_CSS).not.toContain(".cfpt-dock");
   });
 
   it("tracks toggle and rendered status on the light-DOM host", () => {
@@ -78,20 +95,21 @@ describe("embedded composer panel", () => {
     expect(host().dataset["status"]).toBe("awaiting_user");
   });
 
-  it("re-homes the same host when ChatGPT replaces the composer header", async () => {
+  it("re-homes the same host when ChatGPT replaces the composer surface", async () => {
     makePanel();
-    const first = document.querySelector("[data-prompt-textarea-header]");
+    const first = document.querySelector('[data-composer-surface="true"]');
     const replacement = document.createElement("div");
-    replacement.setAttribute("data-prompt-textarea-header", "");
+    replacement.setAttribute("data-composer-surface", "true");
+    replacement.innerHTML = '<div id="prompt-textarea" contenteditable="true"></div>';
     first?.replaceWith(replacement);
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await settle();
 
     expect(replacement.querySelector("#cfpt-root")).toBe(host());
     expect(document.querySelectorAll("#cfpt-root")).toHaveLength(1);
   });
 
-  it("expands the embedded controls for completion instead of creating an overlay", () => {
+  it("expands the composer controls for completion instead of creating a completion overlay", () => {
     const panel = makePanel();
     const complete = {
       ...newRunState("conversation-1", 1),
@@ -105,5 +123,75 @@ describe("embedded composer panel", () => {
 
     expect(host().dataset["expanded"]).toBe("true");
     expect(document.querySelector(".cfpt-modal-backdrop")).toBeNull();
+  });
+});
+
+describe("first-run onboarding", () => {
+  it("shows the launcher tip first, highlights the airplane, then shows setup", async () => {
+    const panel = makePanel();
+    await settle();
+
+    expect(host().dataset["onboarding"]).toBe("tip");
+    expect(host().dataset["highlighted"]).toBe("true");
+
+    await panel.acknowledgeLauncherTip(true);
+    expect(host().dataset["onboarding"]).toBe("setup");
+    expect(host().dataset["highlighted"]).toBe("false");
+    expect(stores.local["cfpt:onboarding:v1"]).toEqual({
+      launcherTipSuppressed: true,
+      setupShown: false,
+    });
+
+    await panel.acknowledgeSetup();
+    expect(host().dataset["onboarding"]).toBe("done");
+    expect(stores.local["cfpt:onboarding:v1"]).toEqual({
+      launcherTipSuppressed: true,
+      setupShown: true,
+    });
+  });
+
+  it("does not show either onboarding surface again after suppression and setup completion", async () => {
+    stores.local["cfpt:onboarding:v1"] = {
+      launcherTipSuppressed: true,
+      setupShown: true,
+    };
+
+    makePanel();
+    await settle();
+
+    expect(host().dataset["onboarding"]).toBe("done");
+    expect(host().dataset["highlighted"]).toBe("false");
+  });
+
+  it("shows the launcher tip again when the user did not check don't-show-again", async () => {
+    const panel = makePanel();
+    await settle();
+    await panel.acknowledgeLauncherTip(false);
+    await panel.acknowledgeSetup();
+    panel.dispose();
+
+    fixture();
+    makePanel();
+    await settle();
+
+    expect(stores.local["cfpt:onboarding:v1"]).toEqual({
+      launcherTipSuppressed: false,
+      setupShown: true,
+    });
+    expect(host().dataset["onboarding"]).toBe("tip");
+    expect(host().dataset["highlighted"]).toBe("true");
+  });
+
+  it("goes directly to the one-time setup dialog when only the launcher tip is suppressed", async () => {
+    stores.local["cfpt:onboarding:v1"] = {
+      launcherTipSuppressed: true,
+      setupShown: false,
+    };
+
+    makePanel();
+    await settle();
+
+    expect(host().dataset["onboarding"]).toBe("setup");
+    expect(host().dataset["highlighted"]).toBe("false");
   });
 });

--- a/tests/panel.test.ts
+++ b/tests/panel.test.ts
@@ -127,6 +127,11 @@ describe("composer airplane launcher", () => {
 });
 
 describe("first-run onboarding", () => {
+  it("uses a dedicated blurred setup backdrop", () => {
+    expect(PANEL_CSS).toContain(".cfpt-setup-backdrop");
+    expect(PANEL_CSS).toContain("backdrop-filter: blur(4px)");
+  });
+
   it("shows the launcher tip first, highlights the airplane, then shows setup", async () => {
     const panel = makePanel();
     await settle();

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -3,7 +3,7 @@ import { healthCheck, query, queryAll, queryLast, resolve } from "../src/content
 
 /**
  * Synthetic fixture shaped from the current chatgpt.com DOM capture: the thread owns
- * section turns, the composer is unified, and Chat FreePT mounts in the prompt header.
+ * section turns, the composer is unified, and Chat FreePT mounts in the composer surface.
  */
 const CHATGPT_FIXTURE = `
   <main id="main">
@@ -54,6 +54,7 @@ describe("selector registry", () => {
   it("resolves primary candidates on the captured ChatGPT structure", () => {
     expect(resolve("composer")?.candidateIndex).toBe(0);
     expect(resolve("composerHeader")?.candidateIndex).toBe(0);
+    expect(resolve("composerSurface")?.candidateIndex).toBe(0);
     expect(resolve("sendButton")?.candidateIndex).toBe(0);
     expect(resolve("conversationRoot")?.candidateIndex).toBe(0);
     expect(resolve("assistantMessage")?.candidateIndex).toBe(0);
@@ -85,12 +86,20 @@ describe("selector registry", () => {
     expect(healthCheck().missing).toEqual([]);
   });
 
-  it("falls back down the composer and composer-header candidate lists", () => {
+  it("falls back down the composer, header, and surface candidate lists", () => {
     document.getElementById("prompt-textarea")?.removeAttribute("id");
     document.getElementById("thread-bottom")?.removeAttribute("id");
 
     expect(resolve("composer")?.candidateIndex).toBeGreaterThan(0);
     expect(resolve("composerHeader")?.candidateIndex).toBeGreaterThan(0);
+    expect(resolve("composerSurface")?.candidateIndex).toBeGreaterThan(0);
+  });
+
+  it("falls back to the unified form when the composer-surface attribute disappears", () => {
+    document.querySelector('[data-composer-surface="true"]')?.removeAttribute("data-composer-surface");
+    const surface = resolve("composerSurface");
+    expect(surface?.element.tagName).toBe("FORM");
+    expect(surface?.candidateIndex).toBe(3);
   });
 
   it("filters text-matched Send candidates", () => {
@@ -118,6 +127,7 @@ describe("selector registry", () => {
     expect(report.missing).toContain("composer");
     expect(report.missing).not.toContain("sendButton");
     expect(report.missing).not.toContain("composerHeader");
+    expect(report.missing).not.toContain("composerSurface");
   });
 
   it("healthCheck reports degradation when the primary composer drifts", () => {

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -96,7 +96,9 @@ describe("selector registry", () => {
   });
 
   it("falls back to the unified form when the composer-surface attribute disappears", () => {
-    document.querySelector('[data-composer-surface="true"]')?.removeAttribute("data-composer-surface");
+    document
+      .querySelector('[data-composer-surface="true"]')
+      ?.removeAttribute("data-composer-surface");
     const surface = resolve("composerSurface");
     expect(surface?.element.tagName).toBe("FORM");
     expect(surface?.candidateIndex).toBe(3);


### PR DESCRIPTION
Refs #36

## Result
Chat FreePT no longer renders a full-width status box above ChatGPT's composer. It now lives behind a compact airplane SVG button inside the existing composer surface. The full Chat FreePT controls open as a floating popover only when requested.

## Implementation
Added a centralized `composerSurface` selector using the captured `[data-composer-surface="true"]` structure with safe fallbacks. Reworked the panel host into a 34px airplane launcher positioned beside ChatGPT's native composer controls, preserving visual run/attention/error/complete states and SPA re-homing. Added first-run onboarding in two sequential surfaces: a lightweight launcher-tip toast that highlights the airplane and includes a "Don't show this tip again" checkbox, followed by a one-time small setup dialog with a blurred backdrop explaining ChatGPT Developer Mode, GitHub's official remote MCP URL, OAuth, conversation app selection, and repository/workflow authorization. Onboarding state is persisted in `chrome.storage.local` under a versioned key and failures never block normal extension controls.

## Verification
Updated selector tests for composer-surface primary/fallback resolution. Updated panel tests for composer-surface mounting, no legacy full-width dock CSS, toggle/state rendering, composer-surface re-home, completion behavior, launcher-tip highlighting, persistence when suppression is selected, repeat behavior when it is not selected, and direct setup-dialog behavior when only the tip is suppressed. Hosted CI must pass metadata, deterministic quality/typecheck, unit/coverage/build/package, dependency audit, and security/supply-chain checks before merge.

## Risk
Low UI integration risk. No new runtime dependencies, extension permissions, GitHub credentials, private ChatGPT APIs, network interception, or CI policy changes. Host selectors remain centralized.

## Remaining work
Live-browser validation is still required after CI using the exact PR artifact to confirm visual placement beside ChatGPT's current send/voice controls and that the fixed blurred setup dialog is not clipped by the live composer DOM.