### PR TITLE
Add continuation controls and queued user input

### DIFF
--- a/src/common/state-machine.ts
+++ b/src/common/state-machine.ts
@@ -15,6 +15,9 @@ export type MachineEvent =
   | { type: "USER_RESUME" }
   | { type: "USER_STOP" }
   | { type: "USER_REPLY"; text: string }
+  | { type: "USER_SET_AUTO_CONTINUE"; enabled: boolean }
+  | { type: "USER_QUEUE_NEXT"; text: string }
+  | { type: "USER_CLEAR_QUEUE" }
   | { type: "INSERT_OK" }
   | { type: "INSERT_FAIL"; detail: string }
   | { type: "SEND_OK" }
@@ -57,11 +60,15 @@ type UserEvent = Extract<
       | "USER_PAUSE"
       | "USER_RESUME"
       | "USER_STOP"
-      | "USER_REPLY";
+      | "USER_REPLY"
+      | "USER_SET_AUTO_CONTINUE"
+      | "USER_QUEUE_NEXT"
+      | "USER_CLEAR_QUEUE";
   }
 >;
 type StartEvent = Extract<UserEvent, { type: "USER_START" }>;
 type UserReplyEvent = Extract<UserEvent, { type: "USER_REPLY" }>;
+type QueueEvent = Extract<UserEvent, { type: "USER_QUEUE_NEXT" }>;
 type SendEvent = Extract<
   MachineEvent,
   { type: "INSERT_OK" | "INSERT_FAIL" | "SEND_OK" | "SEND_FAIL" }
@@ -81,6 +88,9 @@ const USER_EVENTS = new Set<MachineEvent["type"]>([
   "USER_RESUME",
   "USER_STOP",
   "USER_REPLY",
+  "USER_SET_AUTO_CONTINUE",
+  "USER_QUEUE_NEXT",
+  "USER_CLEAR_QUEUE",
 ]);
 const SEND_EVENTS = new Set<MachineEvent["type"]>([
   "INSERT_OK",
@@ -103,6 +113,7 @@ export function newRunState(conversationId: string, now: number): RunState {
     idea: "",
     repoMode: "new",
     repoName: "",
+    autoContinueEnabled: true,
     autoSends: 0,
     nudges: 0,
     repliesSinceContract: 0,
@@ -114,6 +125,10 @@ export function newRunState(conversationId: string, now: number): RunState {
 
 export function isActive(state: RunState): boolean {
   return ACTIVE_STATUSES.has(state.status);
+}
+
+export function autoContinueEnabled(state: RunState): boolean {
+  return state.autoContinueEnabled !== false;
 }
 
 /** Remaining delay for a persisted cooldown. Legacy cooldowns without a deadline resume now. */
@@ -185,6 +200,12 @@ function reduceUserEvent(ctx: ReduceContext, event: UserEvent): boolean {
       return stopRun(ctx);
     case "USER_REPLY":
       return sendUserReply(ctx, event);
+    case "USER_SET_AUTO_CONTINUE":
+      return setAutoContinue(ctx, event.enabled);
+    case "USER_QUEUE_NEXT":
+      return queueNextMessage(ctx, event);
+    case "USER_CLEAR_QUEUE":
+      return clearQueuedMessage(ctx);
   }
 }
 
@@ -202,6 +223,7 @@ function startRun(ctx: ReduceContext, event: StartEvent): boolean {
   state.nudges = 0;
   state.repliesSinceContract = 0;
   state.startedAt = ctx.now;
+  delete state.queuedUserText;
   delete state.errorCode;
   delete state.pauseReason;
   note(ctx, "info", "Planning started");
@@ -244,9 +266,11 @@ function resumeRun(ctx: ReduceContext): boolean {
 }
 
 function stopRun(ctx: ReduceContext): boolean {
-  ctx.state.phase = "stopped";
-  ctx.state.status = "idle";
-  note(ctx, "info", "Stopped");
+  const enabled = autoContinueEnabled(ctx.state);
+  const reset = newRunState(ctx.state.conversationId, ctx.now);
+  reset.autoContinueEnabled = enabled;
+  reset.log = [{ at: ctx.now, kind: "info", text: "Stopped and reset" }];
+  ctx.state = reset;
   ctx.effects.push({ do: "badge", text: "" });
   return true;
 }
@@ -265,6 +289,52 @@ function sendUserReply(ctx: ReduceContext, event: UserReplyEvent): boolean {
     { do: "insertAndSend", kind: "user_text", text: event.text },
     { do: "badge", text: "RUN" },
   );
+  return true;
+}
+
+function setAutoContinue(ctx: ReduceContext, enabled: boolean): boolean {
+  const state = ctx.state;
+  if (autoContinueEnabled(state) === enabled && state.autoContinueEnabled !== undefined) return false;
+  state.autoContinueEnabled = enabled;
+  note(ctx, "info", `Auto-continue ${enabled ? "enabled" : "disabled"}`);
+
+  if (!enabled && state.status === "cooldown" && !state.queuedUserText) {
+    waitForManualContinue(ctx);
+    return true;
+  }
+
+  if (
+    enabled &&
+    state.status === "awaiting_user" &&
+    state.lastMarker?.status === "CONTINUE" &&
+    isContinuablePhase(state)
+  ) {
+    delete state.pauseReason;
+    handleContinue(ctx);
+  }
+  return true;
+}
+
+function queueNextMessage(ctx: ReduceContext, event: QueueEvent): boolean {
+  const text = event.text.trim();
+  if (!text || !isContinuablePhase(ctx.state)) return false;
+  ctx.state.queuedUserText = text;
+  note(ctx, "info", "Queued next user message");
+
+  if (ctx.state.status === "awaiting_user" && ctx.state.lastMarker?.status === "CONTINUE") {
+    delete ctx.state.pauseReason;
+    scheduleContinuation(ctx);
+  }
+  return true;
+}
+
+function clearQueuedMessage(ctx: ReduceContext): boolean {
+  if (!ctx.state.queuedUserText) return false;
+  delete ctx.state.queuedUserText;
+  note(ctx, "info", "Cleared queued user message");
+  if (!autoContinueEnabled(ctx.state) && ctx.state.status === "cooldown") {
+    waitForManualContinue(ctx);
+  }
   return true;
 }
 
@@ -310,21 +380,40 @@ function reduceStreamEvent(ctx: ReduceContext, event: StreamEvent): boolean {
 
 function reduceSystemEvent(ctx: ReduceContext, event: SystemEvent): boolean {
   switch (event.type) {
-    case "COOLDOWN_ELAPSED": {
-      if (ctx.state.status !== "cooldown") return false;
-      ctx.state.status = "inserting";
-      ctx.state.autoSends += 1;
-      const refresh = ctx.state.repliesSinceContract >= ctx.settings.contractRefreshEvery;
-      if (refresh) ctx.state.repliesSinceContract = 0;
-      note(ctx, "send", refresh ? "Auto-continue (with contract refresh)" : "Auto-continue");
-      ctx.effects.push({ do: "insertAndSend", kind: refresh ? "contract_refresh" : "continue" });
-      return true;
-    }
+    case "COOLDOWN_ELAPSED":
+      return finishCooldown(ctx);
     case "PAGE_SIGNAL":
       if (!isActive(ctx.state) && ctx.state.status !== "awaiting_user") return false;
       handlePageSignal(ctx, event.signal);
       return true;
   }
+}
+
+function finishCooldown(ctx: ReduceContext): boolean {
+  const state = ctx.state;
+  if (state.status !== "cooldown") return false;
+
+  if (state.queuedUserText) {
+    const text = state.queuedUserText;
+    delete state.queuedUserText;
+    state.status = "inserting";
+    note(ctx, "send", "Sending queued user message");
+    ctx.effects.push({ do: "insertAndSend", kind: "user_text", text });
+    return true;
+  }
+
+  if (!autoContinueEnabled(state)) {
+    waitForManualContinue(ctx);
+    return true;
+  }
+
+  state.status = "inserting";
+  state.autoSends += 1;
+  const refresh = state.repliesSinceContract >= ctx.settings.contractRefreshEvery;
+  if (refresh) state.repliesSinceContract = 0;
+  note(ctx, "send", refresh ? "Auto-continue (with contract refresh)" : "Auto-continue");
+  ctx.effects.push({ do: "insertAndSend", kind: refresh ? "contract_refresh" : "continue" });
+  return true;
 }
 
 function handlePageSignal(ctx: ReduceContext, signal: PageSignal): void {
@@ -424,8 +513,16 @@ function handleMarker(ctx: ReduceContext, marker: Marker, text: string): void {
 function handleContinue(ctx: ReduceContext): void {
   const state = ctx.state;
   if (state.phase === "plan_ready") state.phase = "planning";
-  if (state.phase !== "planning" && state.phase !== "developing") {
+  if (!isContinuablePhase(state)) {
     state.status = "awaiting_user";
+    return;
+  }
+  if (state.queuedUserText) {
+    scheduleContinuation(ctx);
+    return;
+  }
+  if (!autoContinueEnabled(state)) {
+    waitForManualContinue(ctx);
     return;
   }
   if (state.autoSends >= ctx.settings.autoContinueCap) {
@@ -436,9 +533,24 @@ function handleContinue(ctx: ReduceContext): void {
     );
     return;
   }
-  state.status = "cooldown";
-  state.cooldownUntil = ctx.now + ctx.settings.sendDelayMs;
+  scheduleContinuation(ctx);
+}
+
+function isContinuablePhase(state: RunState): boolean {
+  return state.phase === "planning" || state.phase === "developing";
+}
+
+function scheduleContinuation(ctx: ReduceContext): void {
+  ctx.state.status = "cooldown";
+  ctx.state.cooldownUntil = ctx.now + ctx.settings.sendDelayMs;
   ctx.effects.push({ do: "startCooldown", ms: ctx.settings.sendDelayMs });
+}
+
+function waitForManualContinue(ctx: ReduceContext): void {
+  ctx.state.status = "awaiting_user";
+  ctx.state.pauseReason = "Auto-continue is off.";
+  note(ctx, "info", "Waiting because auto-continue is off");
+  ctx.effects.push({ do: "badge", text: "II" });
 }
 
 function excerpt(text: string): string {

--- a/src/common/state-machine.ts
+++ b/src/common/state-machine.ts
@@ -29,7 +29,13 @@ export type MachineEvent =
   | { type: "PAGE_SIGNAL"; signal: PageSignal };
 
 export type PromptKind =
-  "plan" | "develop" | "continue" | "contract_refresh" | "nudge" | "user_text";
+  | "plan"
+  | "develop"
+  | "continue"
+  | "contract_refresh"
+  | "nudge"
+  | "user_text"
+  | "queued_user_text";
 
 export type Effect =
   | { do: "insertAndSend"; kind: PromptKind; text?: string }
@@ -398,7 +404,7 @@ function finishCooldown(ctx: ReduceContext): boolean {
     delete state.queuedUserText;
     state.status = "inserting";
     note(ctx, "send", "Sending queued user message");
-    ctx.effects.push({ do: "insertAndSend", kind: "user_text", text });
+    ctx.effects.push({ do: "insertAndSend", kind: "queued_user_text", text });
     return true;
   }
 

--- a/src/common/state-machine.ts
+++ b/src/common/state-machine.ts
@@ -29,13 +29,7 @@ export type MachineEvent =
   | { type: "PAGE_SIGNAL"; signal: PageSignal };
 
 export type PromptKind =
-  | "plan"
-  | "develop"
-  | "continue"
-  | "contract_refresh"
-  | "nudge"
-  | "user_text"
-  | "queued_user_text";
+  "plan" | "develop" | "continue" | "contract_refresh" | "nudge" | "user_text" | "queued_user_text";
 
 export type Effect =
   | { do: "insertAndSend"; kind: PromptKind; text?: string }
@@ -300,7 +294,8 @@ function sendUserReply(ctx: ReduceContext, event: UserReplyEvent): boolean {
 
 function setAutoContinue(ctx: ReduceContext, enabled: boolean): boolean {
   const state = ctx.state;
-  if (autoContinueEnabled(state) === enabled && state.autoContinueEnabled !== undefined) return false;
+  if (autoContinueEnabled(state) === enabled && state.autoContinueEnabled !== undefined)
+    return false;
   state.autoContinueEnabled = enabled;
   note(ctx, "info", `Auto-continue ${enabled ? "enabled" : "disabled"}`);
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -65,6 +65,10 @@ export interface RunState {
   planSummary?: string;
   pauseReason?: string;
   errorCode?: ErrorCode;
+  /** Defaults to true for legacy persisted runs where the field is absent. */
+  autoContinueEnabled?: boolean;
+  /** One user-authored message that takes precedence over the next automatic continue. */
+  queuedUserText?: string;
   /** Auto-sends used in the current phase (cap enforced per phase). */
   autoSends: number;
   /** Marker-recovery nudges since the last successful marker parse. Max 1. */

--- a/src/content/run-controller.ts
+++ b/src/content/run-controller.ts
@@ -7,7 +7,7 @@ import {
   buildUserReply,
   NUDGE_PROMPT,
 } from "../common/prompts";
-import type { Effect, MachineEvent } from "../common/state-machine";
+import type { Effect, MachineEvent, PromptKind } from "../common/state-machine";
 import { cooldownRemainingMs, isActive, reduce } from "../common/state-machine";
 import { saveRun } from "../common/storage";
 import type { BgRequest, RunState, Settings } from "../common/types";
@@ -165,7 +165,7 @@ export class RunController {
     this.cooldownTimer = undefined;
   }
 
-  private buildPrompt(kind: string, text?: string): string {
+  private buildPrompt(kind: PromptKind, text?: string): string {
     switch (kind) {
       case "plan":
         return buildPlanPrompt({
@@ -183,13 +183,12 @@ export class RunController {
       case "nudge":
         return NUDGE_PROMPT;
       case "user_text":
+      case "queued_user_text":
         return buildUserReply(text ?? "");
-      default:
-        throw new Error(`unknown prompt kind: ${kind}`);
     }
   }
 
-  private async insertAndSend(kind: string, text?: string): Promise<void> {
+  private async insertAndSend(kind: PromptKind, text?: string): Promise<void> {
     if (this.disposed) return;
     const health = healthCheck();
     if (health.missing.length > 0) {
@@ -200,10 +199,10 @@ export class RunController {
       return;
     }
 
-    // An automated send must never eat a draft the user is typing. Wait briefly for the
-    // composer to clear; a user-initiated send replaces the draft deliberately.
-    const automated = kind !== "plan" && kind !== "develop" && kind !== "user_text";
-    if (automated) {
+    // A delayed/automatic send must never eat a draft the user is typing. Immediate user
+    // replies deliberately replace the composer; queued user text is delayed and must wait.
+    const delayed = kind !== "plan" && kind !== "develop" && kind !== "user_text";
+    if (delayed) {
       let busyChecks = 0;
       while (!composerIsEmpty()) {
         busyChecks += 1;

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -1,4 +1,4 @@
-import type { MachineEvent } from "../../common/state-machine";
+import { autoContinueEnabled, type MachineEvent } from "../../common/state-machine";
 import type { RunState } from "../../common/types";
 import { healthCheck, query } from "../selectors";
 import { PANEL_CSS } from "./styles";
@@ -45,6 +45,10 @@ function normalizeOnboarding(value: unknown): OnboardingState {
     launcherTipSuppressed: candidate.launcherTipSuppressed === true,
     setupShown: candidate.setupShown === true,
   };
+}
+
+function canQueueNext(state: RunState): boolean {
+  return state.phase === "planning" || state.phase === "developing";
 }
 
 /**
@@ -176,7 +180,7 @@ export class Panel {
     const status = passive ? "Active in another tab" : (STATUS_LABEL[state.status] ?? state.status);
     this.launcher.title = `Chat FreePT · ${phaseLabel(state.phase)} · ${status}`;
 
-    const viewKey = `${state.phase}|${state.status}|${state.pauseReason ?? ""}|${passive}`;
+    const viewKey = `${state.phase}|${state.status}|${state.pauseReason ?? ""}|${autoContinueEnabled(state)}|${state.queuedUserText ?? ""}|${passive}`;
     if (viewKey !== this.lastViewKey) {
       this.lastViewKey = viewKey;
       this.stopArmed = false;
@@ -295,28 +299,64 @@ export class Panel {
         : "";
 
     if (passive) return warn + this.passiveHtml(state);
+    const controls = this.automationControlsHtml(state);
 
     switch (state.status) {
       case "idle":
-        return warn + this.ideaFormHtml(state);
+        return warn + controls + this.ideaFormHtml(state);
       case "inserting":
       case "sending":
       case "streaming":
       case "cooldown":
-        return warn + this.runningHtml(state);
+        return warn + controls + this.runningHtml(state);
       case "awaiting_user":
         return (
           warn +
+          controls +
           (state.phase === "plan_ready" ? this.planReadyHtml(state) : this.needsInputHtml(state))
         );
       case "paused":
       case "error":
-        return warn + this.pausedHtml(state);
+        return warn + controls + this.pausedHtml(state);
       case "complete":
-        return warn + this.completeHtml(state);
+        return warn + controls + this.completeHtml(state);
       default:
-        return warn;
+        return warn + controls;
     }
+  }
+
+  private automationControlsHtml(state: RunState): string {
+    const enabled = autoContinueEnabled(state);
+    const queued = state.queuedUserText?.trim() ?? "";
+    const queueControls = canQueueNext(state)
+      ? `
+        <div class="cfpt-field">
+          ${
+            queued
+              ? `<p class="cfpt-note"><strong>Queued next:</strong> ${esc(queued)}</p>
+                 <button class="cfpt-btn" type="button" data-action="showqueue">Edit queued message</button>
+                 <button class="cfpt-btn" type="button" data-action="clearqueue">Clear queued message</button>`
+              : `<button class="cfpt-btn" type="button" data-action="showqueue">Queue next message</button>`
+          }
+          <div class="cfpt-field cfpt-hidden" data-ref="queue-editor">
+            <label>Next user message</label>
+            <textarea data-ref="queue-next" rows="3" placeholder="Send this instead of the next automatic continue…">${esc(queued)}</textarea>
+            <button class="cfpt-btn cfpt-btn-primary" type="button" data-action="savequeue">Save queued message</button>
+            <button class="cfpt-btn" type="button" data-action="hidequeue">Cancel</button>
+          </div>
+        </div>`
+      : "";
+
+    return `
+      <div class="cfpt-field">
+        <label class="cfpt-check-row">
+          <input type="checkbox" data-action="auto-continue" ${enabled ? "checked" : ""} />
+          <span><strong>Auto-continue</strong></span>
+        </label>
+        <p class="cfpt-note">When off, Chat FreePT waits instead of sending its next automatic continue. A queued user message still sends once.</p>
+        ${queueControls}
+      </div>
+    `;
   }
 
   private passiveHtml(state: RunState): string {
@@ -389,14 +429,19 @@ export class Panel {
   }
 
   private needsInputHtml(state: RunState): string {
+    const autoPaused = state.pauseReason === "Auto-continue is off.";
     return `
-      <h3>ChatGPT needs your input</h3>
+      <h3>${autoPaused ? "Auto-continue is off" : "ChatGPT needs your input"}</h3>
       <p class="cfpt-note">${esc(state.pauseReason ?? "See the conversation for the question.")}</p>
-      <div class="cfpt-field">
-        <textarea data-ref="reply" rows="3" placeholder="Type your answer…"></textarea>
-      </div>
-      <button class="cfpt-btn cfpt-btn-primary" data-action="reply">Send reply</button>
-      <button class="cfpt-btn" data-action="resume">I answered in the chat — resume</button>
+      ${
+        autoPaused
+          ? ""
+          : `<div class="cfpt-field">
+               <textarea data-ref="reply" rows="3" placeholder="Type your answer…"></textarea>
+             </div>
+             <button class="cfpt-btn cfpt-btn-primary" data-action="reply">Send reply</button>
+             <button class="cfpt-btn" data-action="resume">I answered in the chat — resume</button>`
+      }
       <button class="cfpt-btn cfpt-btn-danger" data-action="stop">Stop</button>
     `;
   }
@@ -482,6 +527,24 @@ export class Panel {
       case "copyhandoff":
         this.copyHandoff(target);
         break;
+      case "auto-continue":
+        this.hooks.onEvent({
+          type: "USER_SET_AUTO_CONTINUE",
+          enabled: (target as HTMLInputElement).checked,
+        });
+        break;
+      case "showqueue":
+        this.showQueueEditor();
+        break;
+      case "hidequeue":
+        this.hideQueueEditor();
+        break;
+      case "savequeue":
+        this.saveQueuedMessage();
+        break;
+      case "clearqueue":
+        this.hooks.onEvent({ type: "USER_CLEAR_QUEUE" });
+        break;
       case "tip-continue":
         void this.acknowledgeLauncherTip(this.tipCheckboxChecked());
         break;
@@ -506,6 +569,22 @@ export class Panel {
     const text = this.refValue("reply");
     if (!text.trim()) return;
     this.hooks.onEvent({ type: "USER_REPLY", text });
+  }
+
+  private showQueueEditor(): void {
+    const editor = this.panelEl.querySelector<HTMLElement>('[data-ref="queue-editor"]');
+    editor?.classList.remove("cfpt-hidden");
+    this.panelEl.querySelector<HTMLTextAreaElement>('[data-ref="queue-next"]')?.focus();
+  }
+
+  private hideQueueEditor(): void {
+    this.panelEl.querySelector<HTMLElement>('[data-ref="queue-editor"]')?.classList.add("cfpt-hidden");
+  }
+
+  private saveQueuedMessage(): void {
+    const text = this.refValue("queue-next").trim();
+    if (!text) return;
+    this.hooks.onEvent({ type: "USER_QUEUE_NEXT", text });
   }
 
   private stopRun(target: HTMLElement): void {

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -578,7 +578,9 @@ export class Panel {
   }
 
   private hideQueueEditor(): void {
-    this.panelEl.querySelector<HTMLElement>('[data-ref="queue-editor"]')?.classList.add("cfpt-hidden");
+    this.panelEl
+      .querySelector<HTMLElement>('[data-ref="queue-editor"]')
+      ?.classList.add("cfpt-hidden");
   }
 
   private saveQueuedMessage(): void {

--- a/tests/continuation-controls.test.ts
+++ b/tests/continuation-controls.test.ts
@@ -94,7 +94,7 @@ describe("queued continuation input and stop reset", () => {
     expect(result.state.autoSends).toBe(settings.autoContinueCap);
     expect(result.effects).toContainEqual({
       do: "insertAndSend",
-      kind: "user_text",
+      kind: "queued_user_text",
       text: "Run the audit first.",
     });
   });

--- a/tests/continuation-controls.test.ts
+++ b/tests/continuation-controls.test.ts
@@ -34,7 +34,7 @@ function streamingRun(): RunState {
   ]).state;
 }
 
-describe("continuation controls", () => {
+describe("auto-continue control", () => {
   it("defaults new and legacy runs to auto-continue enabled", () => {
     expect(autoContinueEnabled(newRunState("new", 1))).toBe(true);
     const legacy = { ...newRunState("legacy", 1), autoContinueEnabled: undefined };
@@ -72,7 +72,9 @@ describe("continuation controls", () => {
     expect(resumed.state.status).toBe("cooldown");
     expect(resumed.effects).toContainEqual({ do: "startCooldown", ms: 1000 });
   });
+});
 
+describe("queued continuation input and stop reset", () => {
   it("sends a queued user message before continue even when auto-continue is off", () => {
     let state = streamingRun();
     state = reduce(state, { type: "USER_SET_AUTO_CONTINUE", enabled: false }, settings).state;

--- a/tests/continuation-controls.test.ts
+++ b/tests/continuation-controls.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  autoContinueEnabled,
+  newRunState,
+  reduce,
+  type Effect,
+  type MachineEvent,
+} from "../src/common/state-machine";
+import type { Marker, RunState, Settings } from "../src/common/types";
+import { DEFAULT_SETTINGS } from "../src/common/types";
+
+const settings: Settings = { ...DEFAULT_SETTINGS, sendDelayMs: 1000, autoContinueCap: 3 };
+
+function marker(status: Marker["status"]): Marker {
+  return { status, version: 1, raw: status };
+}
+
+function drive(state: RunState, events: MachineEvent[]): { state: RunState; effects: Effect[] } {
+  let current = state;
+  const effects: Effect[] = [];
+  for (const event of events) {
+    const result = reduce(current, event, settings);
+    current = result.state;
+    effects.push(...result.effects);
+  }
+  return { state: current, effects };
+}
+
+function streamingRun(): RunState {
+  return drive(newRunState("c1", 1000), [
+    { type: "USER_START", idea: "build it", repoMode: "new", repoName: "" },
+    { type: "INSERT_OK" },
+    { type: "SEND_OK" },
+  ]).state;
+}
+
+describe("continuation controls", () => {
+  it("defaults new and legacy runs to auto-continue enabled", () => {
+    expect(autoContinueEnabled(newRunState("new", 1))).toBe(true);
+    const legacy = { ...newRunState("legacy", 1), autoContinueEnabled: undefined };
+    expect(autoContinueEnabled(legacy)).toBe(true);
+  });
+
+  it("waits on CONTINUE when auto-continue is disabled", () => {
+    let state = streamingRun();
+    state = reduce(state, { type: "USER_SET_AUTO_CONTINUE", enabled: false }, settings).state;
+    const result = reduce(
+      state,
+      { type: "REPLY_COMPLETE", marker: marker("CONTINUE"), text: "continue" },
+      settings,
+    );
+
+    expect(result.state.status).toBe("awaiting_user");
+    expect(result.state.pauseReason).toBe("Auto-continue is off.");
+    expect(result.effects).not.toContainEqual({ do: "startCooldown", ms: 1000 });
+  });
+
+  it("disabling a pending automatic cooldown stops it and re-enabling resumes it", () => {
+    let state = streamingRun();
+    state = reduce(
+      state,
+      { type: "REPLY_COMPLETE", marker: marker("CONTINUE"), text: "" },
+      settings,
+    ).state;
+    expect(state.status).toBe("cooldown");
+
+    state = reduce(state, { type: "USER_SET_AUTO_CONTINUE", enabled: false }, settings).state;
+    expect(state.status).toBe("awaiting_user");
+    expect(state.cooldownUntil).toBeUndefined();
+
+    const resumed = reduce(state, { type: "USER_SET_AUTO_CONTINUE", enabled: true }, settings);
+    expect(resumed.state.status).toBe("cooldown");
+    expect(resumed.effects).toContainEqual({ do: "startCooldown", ms: 1000 });
+  });
+
+  it("sends a queued user message before continue even when auto-continue is off", () => {
+    let state = streamingRun();
+    state = reduce(state, { type: "USER_SET_AUTO_CONTINUE", enabled: false }, settings).state;
+    state = reduce(state, { type: "USER_QUEUE_NEXT", text: "  Run the audit first.  " }, settings).state;
+    state = { ...state, autoSends: settings.autoContinueCap };
+
+    state = reduce(
+      state,
+      { type: "REPLY_COMPLETE", marker: marker("CONTINUE"), text: "" },
+      settings,
+    ).state;
+    expect(state.status).toBe("cooldown");
+
+    const result = reduce(state, { type: "COOLDOWN_ELAPSED" }, settings);
+    expect(result.state.status).toBe("inserting");
+    expect(result.state.queuedUserText).toBeUndefined();
+    expect(result.state.autoSends).toBe(settings.autoContinueCap);
+    expect(result.effects).toContainEqual({
+      do: "insertAndSend",
+      kind: "user_text",
+      text: "Run the audit first.",
+    });
+  });
+
+  it("returns to waiting after a queued message reply while auto-continue remains off", () => {
+    let state = streamingRun();
+    state = reduce(state, { type: "USER_SET_AUTO_CONTINUE", enabled: false }, settings).state;
+    state = reduce(state, { type: "USER_QUEUE_NEXT", text: "Check the tests." }, settings).state;
+    state = reduce(
+      state,
+      { type: "REPLY_COMPLETE", marker: marker("CONTINUE"), text: "" },
+      settings,
+    ).state;
+    state = reduce(state, { type: "COOLDOWN_ELAPSED" }, settings).state;
+    state = drive(state, [{ type: "INSERT_OK" }, { type: "SEND_OK" }]).state;
+
+    const result = reduce(
+      state,
+      { type: "REPLY_COMPLETE", marker: marker("CONTINUE"), text: "" },
+      settings,
+    );
+    expect(result.state.status).toBe("awaiting_user");
+    expect(result.state.pauseReason).toBe("Auto-continue is off.");
+  });
+
+  it("clearing the only queued message cancels a cooldown when auto-continue is off", () => {
+    let state = streamingRun();
+    state = reduce(state, { type: "USER_SET_AUTO_CONTINUE", enabled: false }, settings).state;
+    state = reduce(state, { type: "USER_QUEUE_NEXT", text: "Do this next." }, settings).state;
+    state = reduce(
+      state,
+      { type: "REPLY_COMPLETE", marker: marker("CONTINUE"), text: "" },
+      settings,
+    ).state;
+    expect(state.status).toBe("cooldown");
+
+    state = reduce(state, { type: "USER_CLEAR_QUEUE" }, settings).state;
+    expect(state.status).toBe("awaiting_user");
+    expect(state.queuedUserText).toBeUndefined();
+    expect(state.cooldownUntil).toBeUndefined();
+  });
+
+  it("STOP resets stale run state while preserving the auto-continue preference", () => {
+    const dirty: RunState = {
+      ...streamingRun(),
+      phase: "developing",
+      status: "cooldown",
+      autoContinueEnabled: false,
+      queuedUserText: "stale instruction",
+      repo: "owner/repo",
+      planSummary: "old plan",
+      pauseReason: "old pause",
+      errorCode: "send-failed",
+      lastMarker: marker("CONTINUE"),
+      cooldownUntil: Date.now() + 5000,
+      autoSends: 2,
+      nudges: 1,
+      repliesSinceContract: 7,
+    };
+
+    const result = reduce(dirty, { type: "USER_STOP" }, settings);
+    expect(result.state.phase).toBe("idle");
+    expect(result.state.status).toBe("idle");
+    expect(result.state.autoContinueEnabled).toBe(false);
+    expect(result.state.queuedUserText).toBeUndefined();
+    expect(result.state.repo).toBeUndefined();
+    expect(result.state.lastMarker).toBeUndefined();
+    expect(result.state.pauseReason).toBeUndefined();
+    expect(result.state.errorCode).toBeUndefined();
+    expect(result.state.cooldownUntil).toBeUndefined();
+    expect(result.state.autoSends).toBe(0);
+    expect(result.state.nudges).toBe(0);
+    expect(result.state.repliesSinceContract).toBe(0);
+    expect(result.effects).toContainEqual({ do: "badge", text: "" });
+  });
+});

--- a/tests/continuation-controls.test.ts
+++ b/tests/continuation-controls.test.ts
@@ -78,7 +78,11 @@ describe("queued continuation input and stop reset", () => {
   it("sends a queued user message before continue even when auto-continue is off", () => {
     let state = streamingRun();
     state = reduce(state, { type: "USER_SET_AUTO_CONTINUE", enabled: false }, settings).state;
-    state = reduce(state, { type: "USER_QUEUE_NEXT", text: "  Run the audit first.  " }, settings).state;
+    state = reduce(
+      state,
+      { type: "USER_QUEUE_NEXT", text: "  Run the audit first.  " },
+      settings,
+    ).state;
     state = { ...state, autoSends: settings.autoContinueCap };
 
     state = reduce(

--- a/tests/continuation-controls.test.ts
+++ b/tests/continuation-controls.test.ts
@@ -37,7 +37,8 @@ function streamingRun(): RunState {
 describe("auto-continue control", () => {
   it("defaults new and legacy runs to auto-continue enabled", () => {
     expect(autoContinueEnabled(newRunState("new", 1))).toBe(true);
-    const legacy = { ...newRunState("legacy", 1), autoContinueEnabled: undefined };
+    const legacy = newRunState("legacy", 1);
+    delete legacy.autoContinueEnabled;
     expect(autoContinueEnabled(legacy)).toBe(true);
   });
 

--- a/tests/continuation-panel.test.ts
+++ b/tests/continuation-panel.test.ts
@@ -109,6 +109,7 @@ describe("panel continuation controls", () => {
     const { panel: current } = makePanel();
     current.render(newRunState("c1", 1));
 
+    expect(shadow.textContent).toContain("Auto-continue");
     expect(shadow.querySelector('[data-action="auto-continue"]')).not.toBeNull();
     expect(shadow.querySelector('[data-action="showqueue"]')).toBeNull();
   });

--- a/tests/continuation-panel.test.ts
+++ b/tests/continuation-panel.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { newRunState } from "../src/common/state-machine";
+import { Panel, type PanelHooks } from "../src/content/ui/panel";
+import { installChromeMock } from "./chrome-mock";
+
+let shadow: ShadowRoot;
+let attachShadowSpy: ReturnType<typeof vi.spyOn>;
+let panel: Panel | undefined;
+
+function fixture(): void {
+  document.body.innerHTML = `
+    <div id="thread-bottom">
+      <div data-prompt-textarea-header></div>
+      <form data-type="unified-composer">
+        <div data-composer-surface="true">
+          <div id="prompt-textarea" contenteditable="true"></div>
+        </div>
+      </form>
+    </div>
+  `;
+}
+
+function makePanel(onEvent = vi.fn()): { panel: Panel; onEvent: ReturnType<typeof vi.fn> } {
+  const hooks: PanelHooks = {
+    onEvent,
+    onNewProject: vi.fn(),
+    getHandoffPrompt: vi.fn(() => "handoff"),
+  };
+  panel = new Panel(hooks);
+  return { panel, onEvent };
+}
+
+beforeEach(() => {
+  const stores = installChromeMock();
+  stores.local["cfpt:onboarding:v1"] = {
+    launcherTipSuppressed: true,
+    setupShown: true,
+  };
+  fixture();
+
+  const original = HTMLElement.prototype.attachShadow;
+  attachShadowSpy = vi.spyOn(HTMLElement.prototype, "attachShadow").mockImplementation(function (
+    this: HTMLElement,
+    init: ShadowRootInit,
+  ) {
+    shadow = original.call(this, init);
+    return shadow;
+  });
+});
+
+afterEach(() => {
+  panel?.dispose();
+  panel = undefined;
+  attachShadowSpy.mockRestore();
+});
+
+describe("panel continuation controls", () => {
+  it("dispatches the auto-continue toggle from the shared controls", () => {
+    const { panel: current, onEvent } = makePanel();
+    current.render({ ...newRunState("c1", 1), phase: "planning", status: "streaming" });
+
+    const toggle = shadow.querySelector<HTMLInputElement>('[data-action="auto-continue"]');
+    expect(toggle?.checked).toBe(true);
+    toggle?.click();
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: "USER_SET_AUTO_CONTINUE",
+      enabled: false,
+    });
+  });
+
+  it("opens the queue editor and dispatches the next user message", () => {
+    const { panel: current, onEvent } = makePanel();
+    current.render({ ...newRunState("c1", 1), phase: "developing", status: "streaming" });
+
+    shadow.querySelector<HTMLButtonElement>('[data-action="showqueue"]')?.click();
+    const editor = shadow.querySelector<HTMLElement>('[data-ref="queue-editor"]');
+    const input = shadow.querySelector<HTMLTextAreaElement>('[data-ref="queue-next"]');
+    expect(editor?.classList.contains("cfpt-hidden")).toBe(false);
+
+    if (input) input.value = "  Run the accessibility checks next.  ";
+    shadow.querySelector<HTMLButtonElement>('[data-action="savequeue"]')?.click();
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: "USER_QUEUE_NEXT",
+      text: "Run the accessibility checks next.",
+    });
+  });
+
+  it("re-renders queued state with edit and clear controls", () => {
+    const { panel: current, onEvent } = makePanel();
+    const state = {
+      ...newRunState("c1", 1),
+      phase: "planning" as const,
+      status: "cooldown" as const,
+      queuedUserText: "Check the release artifact.",
+    };
+
+    current.render(state);
+    expect(shadow.textContent).toContain("Queued next:");
+    expect(shadow.textContent).toContain("Check the release artifact.");
+    expect(shadow.querySelector('[data-action="showqueue"]')?.textContent).toContain("Edit");
+
+    shadow.querySelector<HTMLButtonElement>('[data-action="clearqueue"]')?.click();
+    expect(onEvent).toHaveBeenCalledWith({ type: "USER_CLEAR_QUEUE" });
+  });
+
+  it("does not expose queue controls outside planning or development", () => {
+    const { panel: current } = makePanel();
+    current.render(newRunState("c1", 1));
+
+    expect(shadow.querySelector('[data-action="auto-continue"]')).not.toBeNull();
+    expect(shadow.querySelector('[data-action="showqueue"]')).toBeNull();
+  });
+});

--- a/tests/continuation-storage.test.ts
+++ b/tests/continuation-storage.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { autoContinueEnabled, newRunState } from "../src/common/state-machine";
+import { loadRun, runKey, saveRun } from "../src/common/storage";
+import { installChromeMock } from "./chrome-mock";
+
+let stores: ReturnType<typeof installChromeMock>;
+
+beforeEach(() => {
+  stores = installChromeMock();
+});
+
+describe("continuation state storage", () => {
+  it("loads a legacy v1 run without the new toggle as enabled", async () => {
+    const legacy = newRunState("legacy", 1);
+    delete legacy.autoContinueEnabled;
+    stores.local[runKey("legacy")] = legacy;
+
+    const loaded = await loadRun("legacy");
+    expect(loaded).not.toBeNull();
+    expect(autoContinueEnabled(loaded!)).toBe(true);
+  });
+
+  it("persists the toggle and queued user message with the conversation run", async () => {
+    const state = {
+      ...newRunState("c1", 1),
+      phase: "developing" as const,
+      status: "streaming" as const,
+      autoContinueEnabled: false,
+      queuedUserText: "Run this next.",
+    };
+
+    await saveRun(state);
+    const loaded = await loadRun("c1");
+
+    expect(loaded?.autoContinueEnabled).toBe(false);
+    expect(loaded?.queuedUserText).toBe("Run this next.");
+  });
+});

--- a/tests/run-controller.test.ts
+++ b/tests/run-controller.test.ts
@@ -121,7 +121,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("RunController orchestration", () => {
+describe("RunController sends and continuation controls", () => {
   it("drives a plan prompt through insert and confirmed send", async () => {
     const controller = makeController();
 
@@ -204,7 +204,9 @@ describe("RunController orchestration", () => {
     expect(controller.state.status).toBe("streaming");
     controller.dispose();
   });
+});
 
+describe("RunController recovery and disposal", () => {
   it("accepts a user reply after NEEDS_INPUT and re-enters streaming", async () => {
     const controller = makeController(streamingState());
 

--- a/tests/run-controller.test.ts
+++ b/tests/run-controller.test.ts
@@ -163,6 +163,48 @@ describe("RunController orchestration", () => {
     controller.dispose();
   });
 
+  it("cancels a pending automatic continuation when auto-continue is turned off", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(15_000);
+    const controller = makeController(streamingState());
+
+    watcher().callbacks.onComplete("CHATFREEPT_STATUS: CONTINUE\nV: 1");
+    expect(controller.state.status).toBe("cooldown");
+
+    controller.dispatch({ type: "USER_SET_AUTO_CONTINUE", enabled: false });
+    expect(controller.state.status).toBe("awaiting_user");
+    expect(controller.state.cooldownUntil).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(500);
+    await flushAsync();
+    expect(mocks.insertPrompt).not.toHaveBeenCalled();
+    expect(mocks.clickSend).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("sends queued user text once while auto-continue is disabled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(17_000);
+    const controller = makeController(streamingState());
+
+    controller.dispatch({ type: "USER_SET_AUTO_CONTINUE", enabled: false });
+    controller.dispatch({ type: "USER_QUEUE_NEXT", text: "Run the accessibility audit next." });
+    watcher().callbacks.onComplete("CHATFREEPT_STATUS: CONTINUE\nV: 1");
+    expect(controller.state.status).toBe("cooldown");
+
+    await vi.advanceTimersByTimeAsync(100);
+    await flushAsync();
+
+    expect(String(mocks.insertPrompt.mock.calls[0]?.[0])).toContain(
+      "Run the accessibility audit next.",
+    );
+    expect(mocks.clickSend).toHaveBeenCalledTimes(1);
+    expect(controller.state.autoSends).toBe(0);
+    expect(controller.state.queuedUserText).toBeUndefined();
+    expect(controller.state.status).toBe("streaming");
+    controller.dispose();
+  });
+
   it("accepts a user reply after NEEDS_INPUT and re-enters streaming", async () => {
     const controller = makeController(streamingState());
 

--- a/tests/run-controller.test.ts
+++ b/tests/run-controller.test.ts
@@ -206,6 +206,29 @@ describe("RunController sends and continuation controls", () => {
   });
 });
 
+describe("RunController queued draft safety", () => {
+  it("does not overwrite a draft that appeared after a message was queued", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(18_000);
+    mocks.composerIsEmpty.mockReturnValue(false);
+    const controller = makeController(streamingState());
+
+    controller.dispatch({ type: "USER_QUEUE_NEXT", text: "Run the queued check." });
+    watcher().callbacks.onComplete("CHATFREEPT_STATUS: CONTINUE\nV: 1");
+    expect(controller.state.status).toBe("cooldown");
+
+    await vi.advanceTimersByTimeAsync(15_100);
+    await flushAsync();
+
+    expect(mocks.composerIsEmpty).toHaveBeenCalledTimes(4);
+    expect(mocks.insertPrompt).not.toHaveBeenCalled();
+    expect(mocks.clickSend).not.toHaveBeenCalled();
+    expect(controller.state.status).toBe("error");
+    expect(controller.state.errorCode).toBe("composer-insert-failed");
+    controller.dispose();
+  });
+});
+
 describe("RunController recovery and disposal", () => {
   it("accepts a user reply after NEEDS_INPUT and re-enters streaming", async () => {
     const controller = makeController(streamingState());

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -238,9 +238,9 @@ describe("state machine", () => {
     expect(resumed.effects).toContainEqual({ do: "reconcile" });
   });
 
-  it("USER_STOP archives the run", () => {
+  it("USER_STOP resets the run", () => {
     const state = reduce(toStreaming(start()), { type: "USER_STOP" }, settings).state;
-    expect(state.phase).toBe("stopped");
+    expect(state.phase).toBe("idle");
     expect(state.status).toBe("idle");
   });
 

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -34,7 +34,7 @@ function toStreaming(state: RunState): RunState {
   return drive(state, [{ type: "INSERT_OK" }, { type: "SEND_OK" }]).state;
 }
 
-describe("state machine", () => {
+describe("state machine continuation lifecycle", () => {
   it("USER_START enters planning and requests the plan prompt", () => {
     const initial = newRunState("c1", 1000);
     const { state, effects } = reduce(
@@ -117,7 +117,9 @@ describe("state machine", () => {
     }
     expect(kinds).toContain("contract_refresh");
   });
+});
 
+describe("state machine marker transitions", () => {
   it("NEEDS_INPUT pauses for the user and notifies", () => {
     const streaming = toStreaming(start());
     const { state, effects } = reduce(
@@ -196,7 +198,9 @@ describe("state machine", () => {
     expect(done.status).toBe("complete");
     expect(effects.some((e) => e.do === "showModal")).toBe(true);
   });
+});
 
+describe("state machine recovery and user control", () => {
   it("missing marker nudges once, then pauses", () => {
     let state = toStreaming(start());
     const first = reduce(


### PR DESCRIPTION
Refs #40

## Result
Add deterministic user control over Chat FreePT's continuation loop: Auto-continue can be disabled/re-enabled, one next user message can be queued to replace the next automatic `continue`, and Stop resets stale automation state.

## Implementation
- Store optional run-level `autoContinueEnabled` and `queuedUserText` fields while keeping legacy v1 runs backward compatible.
- Keep continuation decisions in the state machine: queued user text has priority, does not consume the automatic-send cap, and may send once even when Auto-continue is disabled.
- Cancel a pending automatic cooldown when Auto-continue is disabled with no queued message; re-enable from a prior CONTINUE wait to resume normally.
- Reset explicit Stop to a clean idle run while preserving the Auto-continue preference.
- Add shared in-panel Auto-continue and queue-next controls without a second settings subsystem.
- Add focused state-machine, controller, storage, and panel tests.

## Verification
Hosted PR metadata, deterministic/type/format gates, tests/build/package, dependency audit, and security checks must all pass before merge.

## Risk
Product-state/UI change only. No workflow files, dependencies, extension permissions, credentials, or private ChatGPT APIs changed.

## Remaining work
Resolve any hosted CI findings, then squash merge to `dev`. A separate repository-wide DRY/KISS/YAGNI/TDA/SOLID audit follows after this feature is integrated.