### PR TITLE
Apply exact Prettier output to PR #47

### DIFF
--- a/.github/workflows/prettier-state-cleanup-diagnostic.yml
+++ b/.github/workflows/prettier-state-cleanup-diagnostic.yml
@@ -1,0 +1,33 @@
+name: Prettier state cleanup diagnostic
+
+on:
+  pull_request:
+    branches: [work/44-state-ownership-cleanup]
+
+permissions:
+  contents: write
+
+jobs:
+  format:
+    name: Apply formatted state machine
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Install locked Node toolchain
+        run: npm ci --no-audit --no-fund
+      - name: Apply exact Prettier output to cleanup branch
+        run: |
+          git checkout -B work/44-state-ownership-cleanup origin/work/44-state-ownership-cleanup
+          npx prettier --write src/common/state-machine.ts
+          if git diff --quiet -- src/common/state-machine.ts; then
+            echo "State machine is already formatted."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/common/state-machine.ts
+          git commit -m "style: apply exact Prettier output"
+          git push origin HEAD:work/44-state-ownership-cleanup


### PR DESCRIPTION
Refs #48

## Result
Run the repository's locked Prettier against the sole formatter-only blocker on PR #47 and apply the exact output back to the cleanup branch.

## Implementation
Adds one temporary diagnostic workflow on an isolated branch. It checks out `work/44-state-ownership-cleanup`, runs the locked Node install and Prettier on `src/common/state-machine.ts`, and pushes only the formatter result when a change exists.

## Verification
The diagnostic workflow must succeed and PR #47's normal hosted CI must re-trigger on the formatter commit.

## Risk
`risk:ci`. Diagnostic-only workflow; no formatter settings, thresholds, product logic, dependencies, extension permissions, `dev`, or `main` changes.

## Remaining work
Close this PR unmerged after the exact formatting commit lands, then verify PR #47 fully green.