### PR TITLE
Integrate Chat FreePT into the composer and add guided setup

### DIFF
--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -343,7 +343,7 @@ function controlNearText(pattern: RegExp, selector: string): HTMLElement | null 
 function textElement(
   pattern: RegExp,
   root: ParentNode = document,
-  css = "button, a, label, h1, h2, h3, h4, span, div, p",
+  css = "button, a, label, h1, h2, h3, h4, strong, span, div, p",
 ): Element | null {
   let nodes: Element[];
   try {

--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -230,33 +230,29 @@ export function healthCheck(root: ParentNode = document): HealthReport {
 }
 
 /** Optional, text-aware targets used only by the composer integration and opt-in setup guide. */
+const GUIDE_RESOLVERS: Record<GuideTargetId, () => HTMLElement | null> = {
+  composerPlusButton,
+  settingsSecurity: () => clickableText(/^Security and login$/i),
+  developerModeRow,
+  developerModeToggle: () =>
+    controlNearText(
+      /^Developer mode$/i,
+      'button[role="switch"], [role="switch"], input[type="checkbox"]',
+    ),
+  pluginAddButton,
+  pluginNameInput: () => fieldNearLabel(/^(Name|Plugin name)$/i, "input"),
+  pluginServerInput: () =>
+    fieldNearLabel(/(Server URL|Remote MCP|MCP server URL)/i, 'input[type="url"], input'),
+  pluginAuthControl: () => fieldNearLabel(/Authentication/i, 'select, [role="combobox"], button'),
+  pluginRiskCheckbox: () =>
+    controlNearText(/I understand.*continue/i, 'input[type="checkbox"], [role="checkbox"]'),
+  pluginCreateButton: () => clickableText(/^Create$/i),
+  conversationDeveloperMode: () => clickableText(/^Developer mode$/i),
+  conversationGitHubMcp: () => clickableText(/^GitHub MCP$/i) ?? clickableText(/^GitHub$/i),
+};
+
 export function queryGuideTarget(id: GuideTargetId): HTMLElement | null {
-  switch (id) {
-    case "composerPlusButton":
-      return composerPlusButton();
-    case "settingsSecurity":
-      return clickableText(/^Security and login$/i);
-    case "developerModeRow":
-      return developerModeRow();
-    case "developerModeToggle":
-      return controlNearText(/^Developer mode$/i, 'button[role="switch"], [role="switch"], input[type="checkbox"]');
-    case "pluginAddButton":
-      return pluginAddButton();
-    case "pluginNameInput":
-      return fieldNearLabel(/^(Name|Plugin name)$/i, "input");
-    case "pluginServerInput":
-      return fieldNearLabel(/(Server URL|Remote MCP|MCP server URL)/i, 'input[type="url"], input');
-    case "pluginAuthControl":
-      return fieldNearLabel(/Authentication/i, 'select, [role="combobox"], button');
-    case "pluginRiskCheckbox":
-      return controlNearText(/I understand.*continue/i, 'input[type="checkbox"], [role="checkbox"]');
-    case "pluginCreateButton":
-      return clickableText(/^Create$/i);
-    case "conversationDeveloperMode":
-      return clickableText(/^Developer mode$/i);
-    case "conversationGitHubMcp":
-      return clickableText(/^GitHub MCP$/i) ?? clickableText(/^GitHub$/i);
-  }
+  return GUIDE_RESOLVERS[id]();
 }
 
 function composerPlusButton(): HTMLElement | null {
@@ -271,7 +267,9 @@ function composerPlusButton(): HTMLElement | null {
     const found = document.querySelector<HTMLElement>(css);
     if (found) return found;
   }
-  const form = query("composerSurface")?.closest("form") ?? document.querySelector('form[data-type="unified-composer"]');
+  const form =
+    query("composerSurface")?.closest("form") ??
+    document.querySelector('form[data-type="unified-composer"]');
   if (!form) return null;
   return textElement(/^\+$/i, form, "button") as HTMLElement | null;
 }
@@ -281,7 +279,9 @@ function developerModeRow(): HTMLElement | null {
   if (!(label instanceof HTMLElement)) return null;
   let node: HTMLElement | null = label;
   for (let depth = 0; node && depth < 7; depth += 1) {
-    if (node.querySelector('button[role="switch"], [role="switch"], input[type="checkbox"]')) return node;
+    if (node.querySelector('button[role="switch"], [role="switch"], input[type="checkbox"]')) {
+      return node;
+    }
     node = node.parentElement;
   }
   return label.parentElement ?? label;
@@ -294,7 +294,9 @@ function pluginAddButton(): HTMLElement | null {
   if (labeled) return labeled;
   const plus = textElement(/^\+$/, document, "button");
   if (plus instanceof HTMLElement) return plus;
-  const search = document.querySelector<HTMLElement>('input[placeholder*="Search plugin" i], input[type="search"]');
+  const search = document.querySelector<HTMLElement>(
+    'input[placeholder*="Search plugin" i], input[type="search"]',
+  );
   const container = search?.parentElement?.parentElement;
   const buttons = container ? Array.from(container.querySelectorAll<HTMLElement>("button")) : [];
   return buttons.at(-1) ?? null;
@@ -303,7 +305,11 @@ function pluginAddButton(): HTMLElement | null {
 function clickableText(pattern: RegExp): HTMLElement | null {
   const text = textElement(pattern);
   if (!(text instanceof HTMLElement)) return null;
-  return text.closest<HTMLElement>('button, a, [role="button"], [role="tab"], [role="menuitem"], [role="option"]') ?? text;
+  return (
+    text.closest<HTMLElement>(
+      'button, a, [role="button"], [role="tab"], [role="menuitem"], [role="option"]',
+    ) ?? text
+  );
 }
 
 function fieldNearLabel(pattern: RegExp, selector: string): HTMLElement | null {
@@ -334,7 +340,11 @@ function controlNearText(pattern: RegExp, selector: string): HTMLElement | null 
   return null;
 }
 
-function textElement(pattern: RegExp, root: ParentNode = document, css = "button, a, label, h1, h2, h3, h4, span, div, p"): Element | null {
+function textElement(
+  pattern: RegExp,
+  root: ParentNode = document,
+  css = "button, a, label, h1, h2, h3, h4, span, div, p",
+): Element | null {
   let nodes: Element[];
   try {
     nodes = Array.from(root.querySelectorAll(css));
@@ -345,6 +355,10 @@ function textElement(pattern: RegExp, root: ParentNode = document, css = "button
     if (element.getAttribute("aria-hidden") === "true") return false;
     return pattern.test((element.textContent ?? "").trim());
   });
-  matches.sort((a, b) => a.children.length - b.children.length || (a.textContent?.length ?? 0) - (b.textContent?.length ?? 0));
+  matches.sort(
+    (a, b) =>
+      a.children.length - b.children.length ||
+      (a.textContent?.length ?? 0) - (b.textContent?.length ?? 0),
+  );
   return matches[0] ?? null;
 }

--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -18,6 +18,20 @@ export type TargetId =
   | "pageAlert"
   | "toolIndicator";
 
+export type GuideTargetId =
+  | "composerPlusButton"
+  | "settingsSecurity"
+  | "developerModeRow"
+  | "developerModeToggle"
+  | "pluginAddButton"
+  | "pluginNameInput"
+  | "pluginServerInput"
+  | "pluginAuthControl"
+  | "pluginRiskCheckbox"
+  | "pluginCreateButton"
+  | "conversationDeveloperMode"
+  | "conversationGitHubMcp";
+
 export interface Candidate {
   css: string;
   /** When present, css hits are filtered by visible text. */
@@ -213,4 +227,124 @@ export function healthCheck(root: ParentNode = document): HealthReport {
     }
   }
   return { missing, degraded };
+}
+
+/** Optional, text-aware targets used only by the composer integration and opt-in setup guide. */
+export function queryGuideTarget(id: GuideTargetId): HTMLElement | null {
+  switch (id) {
+    case "composerPlusButton":
+      return composerPlusButton();
+    case "settingsSecurity":
+      return clickableText(/^Security and login$/i);
+    case "developerModeRow":
+      return developerModeRow();
+    case "developerModeToggle":
+      return controlNearText(/^Developer mode$/i, 'button[role="switch"], [role="switch"], input[type="checkbox"]');
+    case "pluginAddButton":
+      return pluginAddButton();
+    case "pluginNameInput":
+      return fieldNearLabel(/^(Name|Plugin name)$/i, "input");
+    case "pluginServerInput":
+      return fieldNearLabel(/(Server URL|Remote MCP|MCP server URL)/i, 'input[type="url"], input');
+    case "pluginAuthControl":
+      return fieldNearLabel(/Authentication/i, 'select, [role="combobox"], button');
+    case "pluginRiskCheckbox":
+      return controlNearText(/I understand.*continue/i, 'input[type="checkbox"], [role="checkbox"]');
+    case "pluginCreateButton":
+      return clickableText(/^Create$/i);
+    case "conversationDeveloperMode":
+      return clickableText(/^Developer mode$/i);
+    case "conversationGitHubMcp":
+      return clickableText(/^GitHub MCP$/i) ?? clickableText(/^GitHub$/i);
+  }
+}
+
+function composerPlusButton(): HTMLElement | null {
+  const selectors = [
+    'button[data-testid="composer-plus-btn"]',
+    'button[aria-label*="Add photos" i]',
+    'button[aria-label*="Add files" i]',
+    'button[aria-label*="Attach" i]',
+    'button[aria-label*="Upload" i]',
+  ];
+  for (const css of selectors) {
+    const found = document.querySelector<HTMLElement>(css);
+    if (found) return found;
+  }
+  const form = query("composerSurface")?.closest("form") ?? document.querySelector('form[data-type="unified-composer"]');
+  if (!form) return null;
+  return textElement(/^\+$/i, form, "button") as HTMLElement | null;
+}
+
+function developerModeRow(): HTMLElement | null {
+  const label = textElement(/^Developer mode$/i);
+  if (!(label instanceof HTMLElement)) return null;
+  let node: HTMLElement | null = label;
+  for (let depth = 0; node && depth < 7; depth += 1) {
+    if (node.querySelector('button[role="switch"], [role="switch"], input[type="checkbox"]')) return node;
+    node = node.parentElement;
+  }
+  return label.parentElement ?? label;
+}
+
+function pluginAddButton(): HTMLElement | null {
+  const labeled = document.querySelector<HTMLElement>(
+    'button[aria-label*="Add plugin" i], button[aria-label*="Create plugin" i], button[title*="Add plugin" i]',
+  );
+  if (labeled) return labeled;
+  const plus = textElement(/^\+$/, document, "button");
+  if (plus instanceof HTMLElement) return plus;
+  const search = document.querySelector<HTMLElement>('input[placeholder*="Search plugin" i], input[type="search"]');
+  const container = search?.parentElement?.parentElement;
+  const buttons = container ? Array.from(container.querySelectorAll<HTMLElement>("button")) : [];
+  return buttons.at(-1) ?? null;
+}
+
+function clickableText(pattern: RegExp): HTMLElement | null {
+  const text = textElement(pattern);
+  if (!(text instanceof HTMLElement)) return null;
+  return text.closest<HTMLElement>('button, a, [role="button"], [role="tab"], [role="menuitem"], [role="option"]') ?? text;
+}
+
+function fieldNearLabel(pattern: RegExp, selector: string): HTMLElement | null {
+  const label = textElement(pattern, document, "label, span, div, p");
+  if (!(label instanceof HTMLElement)) return null;
+  if (label instanceof HTMLLabelElement && label.htmlFor) {
+    const linked = document.getElementById(label.htmlFor);
+    if (linked instanceof HTMLElement) return linked;
+  }
+  let node: HTMLElement | null = label;
+  for (let depth = 0; node && depth < 5; depth += 1) {
+    const control = node.querySelector<HTMLElement>(selector);
+    if (control) return control;
+    node = node.parentElement;
+  }
+  return null;
+}
+
+function controlNearText(pattern: RegExp, selector: string): HTMLElement | null {
+  const label = textElement(pattern);
+  if (!(label instanceof HTMLElement)) return null;
+  let node: HTMLElement | null = label;
+  for (let depth = 0; node && depth < 7; depth += 1) {
+    const control = node.querySelector<HTMLElement>(selector);
+    if (control) return control;
+    node = node.parentElement;
+  }
+  return null;
+}
+
+function textElement(pattern: RegExp, root: ParentNode = document, css = "button, a, label, h1, h2, h3, h4, span, div, p"): Element | null {
+  let nodes: Element[];
+  try {
+    nodes = Array.from(root.querySelectorAll(css));
+  } catch {
+    return null;
+  }
+  const matches = nodes.filter((element) => {
+    if (element.getAttribute("aria-hidden") === "true") return false;
+    return pattern.test((element.textContent ?? "").trim());
+  });
+  matches.sort((a, b) => a.children.length - b.children.length || (a.textContent?.length ?? 0) - (b.textContent?.length ?? 0));
+  return matches[0] ?? null;
 }

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -168,7 +168,11 @@ export class Panel {
     this.toggle(true);
   }
 
-  private createLauncher(): { host: HTMLSpanElement; shadow: ShadowRoot; button: HTMLButtonElement } {
+  private createLauncher(): {
+    host: HTMLSpanElement;
+    shadow: ShadowRoot;
+    button: HTMLButtonElement;
+  } {
     const host = document.createElement("span");
     host.id = "cfpt-root";
     host.dataset["cfptEmbedded"] = "true";
@@ -251,7 +255,10 @@ export class Panel {
   };
 
   private stopComposerPropagation(event: Event): void {
-    if (event.composedPath().includes(this.panelEl) || event.composedPath().includes(this.setupBackdropEl)) {
+    if (
+      event.composedPath().includes(this.panelEl) ||
+      event.composedPath().includes(this.setupBackdropEl)
+    ) {
       event.stopPropagation();
     }
   }
@@ -360,7 +367,8 @@ export class Panel {
     const surface = query("composerSurface");
     if (!(surface instanceof HTMLElement)) return;
     const style = getComputedStyle(surface);
-    if (style.backgroundColor) this.overlayHost.style.setProperty("--cfpt-native-surface", style.backgroundColor);
+    if (style.backgroundColor)
+      this.overlayHost.style.setProperty("--cfpt-native-surface", style.backgroundColor);
     if (style.color) this.overlayHost.style.setProperty("--cfpt-native-text", style.color);
   }
 
@@ -396,8 +404,12 @@ export class Panel {
     const viewportWidth = Math.max(320, window.innerWidth);
     const margin = viewportWidth <= 620 ? 8 : 12;
     const fallbackWidth = Math.min(820, viewportWidth - margin * 2);
-    const width = rect.width >= 280 ? Math.min(rect.width, viewportWidth - margin * 2) : fallbackWidth;
-    const left = rect.width >= 280 ? Math.min(Math.max(margin, rect.left), viewportWidth - width - margin) : (viewportWidth - width) / 2;
+    const width =
+      rect.width >= 280 ? Math.min(rect.width, viewportWidth - margin * 2) : fallbackWidth;
+    const left =
+      rect.width >= 280
+        ? Math.min(Math.max(margin, rect.left), viewportWidth - width - margin)
+        : (viewportWidth - width) / 2;
     const bottom = rect.height > 0 ? Math.max(8, window.innerHeight - rect.bottom) : 16;
     Object.assign(this.panelEl.style, {
       left: `${Math.round(left)}px`,
@@ -411,7 +423,10 @@ export class Panel {
   private positionLauncherTip(): void {
     const rect = this.host.getBoundingClientRect();
     const width = Math.min(310, window.innerWidth - 24);
-    const left = Math.min(Math.max(12, rect.left - 10), Math.max(12, window.innerWidth - width - 12));
+    const left = Math.min(
+      Math.max(12, rect.left - 10),
+      Math.max(12, window.innerWidth - width - 12),
+    );
     const top = rect.top > 175 ? rect.top - 165 : rect.bottom + 10;
     Object.assign(this.launcherTipEl.style, {
       left: `${Math.round(left)}px`,
@@ -454,7 +469,9 @@ export class Panel {
       case "cooldown":
         return this.runningHtml(state);
       case "awaiting_user":
-        return state.phase === "plan_ready" ? this.planReadyHtml(state) : this.needsInputHtml(state);
+        return state.phase === "plan_ready"
+          ? this.planReadyHtml(state)
+          : this.needsInputHtml(state);
       case "paused":
       case "error":
         return this.pausedHtml(state);
@@ -533,7 +550,9 @@ export class Panel {
 
   private runningHtml(state: RunState): string {
     const sendNow =
-      state.status === "cooldown" ? `<button class="cfpt-btn" data-action="sendnow">Send now</button>` : "";
+      state.status === "cooldown"
+        ? `<button class="cfpt-btn" data-action="sendnow">Send now</button>`
+        : "";
     return `
       <div class="cfpt-status-line"><span class="cfpt-spinner"></span>
         <strong data-ref="statusline">${esc(STATUS_LABEL[state.status] ?? state.status)}</strong>
@@ -751,9 +770,7 @@ export class Panel {
 
   private refValue(ref: string): string {
     const el = this.panelEl.querySelector(`[data-ref="${ref}"]`) as
-      | HTMLTextAreaElement
-      | HTMLInputElement
-      | null;
+      HTMLTextAreaElement | HTMLInputElement | null;
     return el?.value ?? "";
   }
 

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -4,7 +4,8 @@ import {
   type MachineEvent,
 } from "../../common/state-machine";
 import type { RunState } from "../../common/types";
-import { healthCheck, query } from "../selectors";
+import { healthCheck, query, queryGuideTarget } from "../selectors";
+import { SetupGuide } from "./setup-guide";
 import { PANEL_CSS } from "./styles";
 
 export interface PanelHooks {
@@ -15,6 +16,12 @@ export interface PanelHooks {
 interface OnboardingState {
   launcherTipSuppressed: boolean;
   setupShown: boolean;
+}
+
+interface NativeSurfaceSnapshot {
+  element: HTMLElement;
+  pointerEvents: string;
+  ariaHidden: string | null;
 }
 
 const ONBOARDING_KEY = "cfpt:onboarding:v1";
@@ -54,16 +61,15 @@ function canQueueNext(state: RunState): boolean {
   return state.phase === "planning" || state.phase === "developing";
 }
 
-/**
- * Compact Chat FreePT controls mounted directly inside ChatGPT's composer surface. The
- * airplane launcher is always present; the full controls float above it only while open.
- * A closed shadow root isolates both style systems while a subtree observer re-homes the
- * single host when ChatGPT replaces its composer during SPA navigation or hydration.
- */
+/** Native-feeling launcher plus a body-level composer takeover that cannot inherit ChatGPT focus traps. */
 export class Panel {
-  private readonly host: HTMLDivElement;
-  private readonly shadow: ShadowRoot;
+  private readonly setupGuide = new SetupGuide();
+  private readonly host: HTMLSpanElement;
+  private readonly launcherShadow: ShadowRoot;
   private readonly launcher: HTMLButtonElement;
+  private readonly overlayHost: HTMLDivElement;
+  private readonly shadow: ShadowRoot;
+  private readonly takeoverBackdropEl: HTMLDivElement;
   private readonly panelEl: HTMLDivElement;
   private readonly launcherTipEl: HTMLDivElement;
   private readonly setupBackdropEl: HTMLDivElement;
@@ -73,93 +79,23 @@ export class Panel {
   private mountQueued = false;
   private disposed = false;
   private onboarding = { ...DEFAULT_ONBOARDING };
+  private nativeSurface: NativeSurfaceSnapshot | null = null;
 
   constructor(private readonly hooks: PanelHooks) {
-    this.host = document.createElement("div");
-    this.host.id = "cfpt-root";
-    this.host.dataset["cfptEmbedded"] = "true";
-    this.host.dataset["cfptLauncher"] = "airplane";
-    this.host.dataset["expanded"] = "false";
-    this.host.dataset["onboarding"] = "loading";
-    this.host.dataset["highlighted"] = "false";
-    this.shadow = this.host.attachShadow({ mode: "closed" });
+    const launcherParts = this.createLauncher();
+    this.host = launcherParts.host;
+    this.launcherShadow = launcherParts.shadow;
+    this.launcher = launcherParts.button;
 
-    const style = document.createElement("style");
-    style.textContent = PANEL_CSS;
-    this.shadow.appendChild(style);
+    const overlay = this.createOverlay();
+    this.overlayHost = overlay.host;
+    this.shadow = overlay.shadow;
+    this.takeoverBackdropEl = overlay.backdrop;
+    this.panelEl = overlay.panel;
+    this.launcherTipEl = overlay.tip;
+    this.setupBackdropEl = overlay.setup;
 
-    this.panelEl = document.createElement("div");
-    this.panelEl.className = "cfpt-panel cfpt-hidden";
-    this.shadow.appendChild(this.panelEl);
-
-    this.launcher = document.createElement("button");
-    this.launcher.type = "button";
-    this.launcher.className = "cfpt-launcher";
-    this.launcher.title = "Open Chat FreePT";
-    this.launcher.setAttribute("aria-label", "Open Chat FreePT");
-    this.launcher.setAttribute("aria-expanded", "false");
-    this.launcher.innerHTML = `
-      <svg class="cfpt-airplane" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M12 2.5c-.8 0-1.4.6-1.4 1.4v5.3L3 13.8v2l7.6-2.4v4.2l-2.3 1.7v1.4l3.7-1.1 3.7 1.1v-1.4l-2.3-1.7v-4.2l7.6 2.4v-2l-7.6-4.6V3.9c0-.8-.6-1.4-1.4-1.4Z"></path>
-      </svg>
-    `;
-    this.launcher.addEventListener("click", () => {
-      if (!this.launcherTipEl.classList.contains("cfpt-hidden")) {
-        void this.acknowledgeLauncherTip(this.tipCheckboxChecked());
-      }
-      this.toggle();
-    });
-    this.shadow.appendChild(this.launcher);
-
-    this.launcherTipEl = document.createElement("div");
-    this.launcherTipEl.className = "cfpt-onboarding-toast cfpt-hidden";
-    this.launcherTipEl.setAttribute("role", "status");
-    this.launcherTipEl.innerHTML = `
-      <div class="cfpt-toast-arrow" aria-hidden="true"></div>
-      <button class="cfpt-icon-close" type="button" data-action="tip-continue" aria-label="Dismiss launcher tip">×</button>
-      <strong>Chat FreePT lives here</strong>
-      <p>Use the airplane inside the ChatGPT input whenever you want to open Chat FreePT.</p>
-      <label class="cfpt-check-row">
-        <input type="checkbox" data-ref="suppress-launcher-tip" />
-        <span>Don't show this tip again</span>
-      </label>
-      <button class="cfpt-btn cfpt-btn-primary cfpt-toast-continue" type="button" data-action="tip-continue">Continue</button>
-    `;
-    this.shadow.appendChild(this.launcherTipEl);
-
-    this.setupBackdropEl = document.createElement("div");
-    this.setupBackdropEl.className = "cfpt-setup-backdrop cfpt-hidden";
-    this.setupBackdropEl.setAttribute("role", "presentation");
-    this.setupBackdropEl.innerHTML = `
-      <section class="cfpt-setup-card" role="dialog" aria-modal="true" aria-labelledby="cfpt-setup-title">
-        <button class="cfpt-icon-close" type="button" data-action="setup-done" aria-label="Close setup instructions">×</button>
-        <div class="cfpt-setup-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2.5c-.8 0-1.4.6-1.4 1.4v5.3L3 13.8v2l7.6-2.4v4.2l-2.3 1.7v1.4l3.7-1.1 3.7 1.1v-1.4l-2.3-1.7v-4.2l7.6 2.4v-2l-7.6-4.6V3.9c0-.8-.6-1.4-1.4-1.4Z"></path></svg>
-        </div>
-        <h2 id="cfpt-setup-title">Set up GitHub access once</h2>
-        <p class="cfpt-setup-lead">For fully autonomous new-repository work, ChatGPT needs a GitHub MCP app with repository and workflow write access.</p>
-        <ol class="cfpt-setup-steps">
-          <li>Open <strong>Settings → Security and login → Developer mode</strong> and turn it on.</li>
-          <li>Open ChatGPT Plugins, select <strong>+</strong>, and add <code>https://api.githubcopilot.com/mcp/</code> using OAuth.</li>
-          <li>In the conversation's Plus menu, choose <strong>Developer mode</strong> and select that GitHub app.</li>
-          <li>Authorize the repository and workflow write access Chat FreePT's preflight requests.</li>
-        </ol>
-        <p class="cfpt-setup-footnote">Existing repositories may work with another GitHub connector if it passes Chat FreePT's capability preflight. Chat FreePT never receives your GitHub credentials.</p>
-        <div class="cfpt-setup-actions">
-          <a class="cfpt-btn" href="https://chatgpt.com/plugins" target="_blank" rel="noreferrer noopener">Open ChatGPT Plugins</a>
-          <button class="cfpt-btn cfpt-btn-primary" type="button" data-action="setup-done">Got it</button>
-        </div>
-      </section>
-    `;
-    this.shadow.appendChild(this.setupBackdropEl);
-
-    this.shadow.addEventListener("click", (event) => this.onClick(event));
-    this.setupBackdropEl.addEventListener("keydown", (event) => {
-      if (event.key === "Escape" && !this.setupBackdropEl.classList.contains("cfpt-hidden")) {
-        void this.acknowledgeSetup();
-      }
-    });
-
+    this.bindEvents();
     this.mountObserver = new MutationObserver(() => this.scheduleMount());
     this.mountObserver.observe(document.documentElement, { childList: true, subtree: true });
     this.mount();
@@ -167,11 +103,18 @@ export class Panel {
   }
 
   toggle(force?: boolean): void {
-    const show = force ?? this.panelEl.classList.contains("cfpt-hidden");
+    const show = force ?? this.takeoverBackdropEl.classList.contains("cfpt-hidden");
+    this.takeoverBackdropEl.classList.toggle("cfpt-hidden", !show);
     this.panelEl.classList.toggle("cfpt-hidden", !show);
     this.host.dataset["expanded"] = String(show);
     this.launcher.setAttribute("aria-expanded", String(show));
     this.launcher.setAttribute("aria-label", show ? "Close Chat FreePT" : "Open Chat FreePT");
+    if (show) {
+      this.applyNativeTakeover();
+      this.positionTakeover();
+    } else {
+      this.restoreNativeTakeover();
+    }
   }
 
   render(state: RunState, passive = false): void {
@@ -187,16 +130,22 @@ export class Panel {
     if (viewKey !== this.lastViewKey) {
       this.lastViewKey = viewKey;
       this.stopArmed = false;
-      this.panelEl.innerHTML = `<div class="cfpt-body">${this.bodyHtml(state, passive)}</div>`;
+      this.panelEl.innerHTML = this.panelShell(this.bodyHtml(state, passive));
     }
     this.updateDynamic(state);
     this.mount();
+    if (this.host.dataset["expanded"] === "true") this.positionTakeover();
   }
 
   dispose(): void {
     this.disposed = true;
     this.mountObserver.disconnect();
+    window.removeEventListener("resize", this.onViewportChange);
+    window.removeEventListener("scroll", this.onViewportChange, true);
+    this.restoreNativeTakeover();
+    this.setupGuide.dispose();
     this.host.remove();
+    this.overlayHost.remove();
   }
 
   async acknowledgeLauncherTip(suppress: boolean): Promise<void> {
@@ -204,11 +153,8 @@ export class Panel {
     this.host.dataset["highlighted"] = "false";
     if (suppress) this.onboarding.launcherTipSuppressed = true;
     await this.persistOnboarding();
-    if (!this.onboarding.setupShown) {
-      this.showSetupModal();
-    } else {
-      this.host.dataset["onboarding"] = "done";
-    }
+    if (!this.onboarding.setupShown) this.showSetupModal();
+    else this.host.dataset["onboarding"] = "done";
   }
 
   async acknowledgeSetup(): Promise<void> {
@@ -222,6 +168,110 @@ export class Panel {
     this.toggle(true);
   }
 
+  private createLauncher(): { host: HTMLSpanElement; shadow: ShadowRoot; button: HTMLButtonElement } {
+    const host = document.createElement("span");
+    host.id = "cfpt-root";
+    host.dataset["cfptEmbedded"] = "true";
+    host.dataset["cfptLauncher"] = "airplane";
+    host.dataset["cfptHost"] = "launcher";
+    host.dataset["expanded"] = "false";
+    host.dataset["onboarding"] = "loading";
+    host.dataset["highlighted"] = "false";
+    host.dataset["fallback"] = "false";
+
+    const shadow = host.attachShadow({ mode: "closed" });
+    appendStyle(shadow);
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "cfpt-launcher";
+    button.title = "Open Chat FreePT";
+    button.setAttribute("aria-label", "Open Chat FreePT");
+    button.setAttribute("aria-expanded", "false");
+    button.innerHTML = airplaneSvg();
+    button.addEventListener("click", () => this.onLauncherClick());
+    shadow.appendChild(button);
+    return { host, shadow, button };
+  }
+
+  private createOverlay(): {
+    host: HTMLDivElement;
+    shadow: ShadowRoot;
+    backdrop: HTMLDivElement;
+    panel: HTMLDivElement;
+    tip: HTMLDivElement;
+    setup: HTMLDivElement;
+  } {
+    const host = document.createElement("div");
+    host.id = "cfpt-overlay-root";
+    host.dataset["cfptHost"] = "overlay";
+    const shadow = host.attachShadow({ mode: "closed" });
+    appendStyle(shadow);
+
+    const backdrop = document.createElement("div");
+    backdrop.className = "cfpt-takeover-backdrop cfpt-hidden";
+    const panel = document.createElement("div");
+    panel.className = "cfpt-panel cfpt-hidden";
+    panel.setAttribute("role", "dialog");
+    panel.setAttribute("aria-modal", "true");
+    backdrop.appendChild(panel);
+    shadow.appendChild(backdrop);
+
+    const tip = document.createElement("div");
+    tip.className = "cfpt-onboarding-toast cfpt-hidden";
+    tip.setAttribute("role", "status");
+    tip.innerHTML = launcherTipHtml();
+    shadow.appendChild(tip);
+
+    const setup = document.createElement("div");
+    setup.className = "cfpt-setup-backdrop cfpt-hidden";
+    shadow.appendChild(setup);
+    document.body.appendChild(host);
+    return { host, shadow, backdrop, panel, tip, setup };
+  }
+
+  private bindEvents(): void {
+    this.shadow.addEventListener("click", (event) => this.onClick(event));
+    this.shadow.addEventListener("pointerdown", (event) => this.stopComposerPropagation(event));
+    this.shadow.addEventListener("mousedown", (event) => this.stopComposerPropagation(event));
+    this.shadow.addEventListener("focusin", (event) => this.stopComposerPropagation(event));
+    this.shadow.addEventListener("keydown", (event) => this.onKeyDown(event));
+    this.takeoverBackdropEl.addEventListener("click", (event) => {
+      if (event.target === this.takeoverBackdropEl) this.toggle(false);
+    });
+    this.setupBackdropEl.addEventListener("click", (event) => {
+      if (event.target === this.setupBackdropEl) void this.acknowledgeSetup();
+    });
+    window.addEventListener("resize", this.onViewportChange);
+    window.addEventListener("scroll", this.onViewportChange, true);
+  }
+
+  private readonly onViewportChange = (): void => {
+    if (this.host.dataset["expanded"] === "true") this.positionTakeover();
+    if (!this.launcherTipEl.classList.contains("cfpt-hidden")) this.positionLauncherTip();
+  };
+
+  private stopComposerPropagation(event: Event): void {
+    if (event.composedPath().includes(this.panelEl) || event.composedPath().includes(this.setupBackdropEl)) {
+      event.stopPropagation();
+    }
+  }
+
+  private onKeyDown(event: Event): void {
+    if (!(event instanceof KeyboardEvent) || event.key !== "Escape") return;
+    if (!this.setupBackdropEl.classList.contains("cfpt-hidden")) {
+      void this.acknowledgeSetup();
+      return;
+    }
+    if (this.host.dataset["expanded"] === "true") this.toggle(false);
+  }
+
+  private onLauncherClick(): void {
+    if (!this.launcherTipEl.classList.contains("cfpt-hidden")) {
+      void this.acknowledgeLauncherTip(this.tipCheckboxChecked());
+    }
+    this.toggle();
+  }
+
   private async initOnboarding(): Promise<void> {
     try {
       const found = await chrome.storage.local.get(ONBOARDING_KEY);
@@ -230,16 +280,9 @@ export class Panel {
       this.onboarding = { ...DEFAULT_ONBOARDING };
     }
     if (this.disposed) return;
-
-    if (!this.onboarding.launcherTipSuppressed) {
-      this.showLauncherTip();
-      return;
-    }
-    if (!this.onboarding.setupShown) {
-      this.showSetupModal();
-      return;
-    }
-    this.host.dataset["onboarding"] = "done";
+    if (!this.onboarding.launcherTipSuppressed) this.showLauncherTip();
+    else if (!this.onboarding.setupShown) this.showSetupModal();
+    else this.host.dataset["onboarding"] = "done";
   }
 
   private async persistOnboarding(): Promise<void> {
@@ -255,19 +298,27 @@ export class Panel {
     this.launcherTipEl.classList.remove("cfpt-hidden");
     this.host.dataset["onboarding"] = "tip";
     this.host.dataset["highlighted"] = "true";
+    this.positionLauncherTip();
   }
 
-  private showSetupModal(): void {
+  private showSetupModal(mode: "paid" | "free" = "paid"): void {
     this.launcherTipEl.classList.add("cfpt-hidden");
     this.host.dataset["highlighted"] = "false";
+    this.setupBackdropEl.innerHTML = mode === "free" ? freeSetupHtml() : paidSetupHtml();
     this.setupBackdropEl.classList.remove("cfpt-hidden");
     this.host.dataset["onboarding"] = "setup";
     queueMicrotask(() => {
-      const button = this.setupBackdropEl.querySelector<HTMLButtonElement>(
-        '[data-action="setup-done"]',
-      );
-      button?.focus();
+      this.setupBackdropEl.querySelector<HTMLButtonElement>("button")?.focus();
     });
+  }
+
+  private async startSetupGuide(): Promise<void> {
+    this.setupBackdropEl.classList.add("cfpt-hidden");
+    this.onboarding.setupShown = true;
+    this.host.dataset["onboarding"] = "done";
+    await this.persistOnboarding();
+    this.toggle(false);
+    await this.setupGuide.start();
   }
 
   private tipCheckboxChecked(): boolean {
@@ -287,9 +338,97 @@ export class Panel {
   }
 
   private mount(): void {
-    const anchor = query("composerSurface") ?? query("composerHeader");
-    if (!anchor || this.host.parentElement === anchor) return;
-    anchor.appendChild(this.host);
+    const plus = queryGuideTarget("composerPlusButton");
+    if (plus?.parentElement) {
+      if (plus.nextElementSibling !== this.host) plus.insertAdjacentElement("afterend", this.host);
+      this.host.dataset["fallback"] = "false";
+    } else {
+      const anchor = query("composerSurface") ?? query("composerHeader");
+      if (anchor && this.host.parentElement !== anchor) anchor.appendChild(this.host);
+      this.host.dataset["fallback"] = "true";
+    }
+    if (!this.overlayHost.isConnected) document.body.appendChild(this.overlayHost);
+    this.syncOverlayTheme();
+    if (this.host.dataset["expanded"] === "true") {
+      this.applyNativeTakeover();
+      this.positionTakeover();
+    }
+    if (!this.launcherTipEl.classList.contains("cfpt-hidden")) this.positionLauncherTip();
+  }
+
+  private syncOverlayTheme(): void {
+    const surface = query("composerSurface");
+    if (!(surface instanceof HTMLElement)) return;
+    const style = getComputedStyle(surface);
+    if (style.backgroundColor) this.overlayHost.style.setProperty("--cfpt-native-surface", style.backgroundColor);
+    if (style.color) this.overlayHost.style.setProperty("--cfpt-native-text", style.color);
+  }
+
+  private applyNativeTakeover(): void {
+    const surface = query("composerSurface");
+    if (!(surface instanceof HTMLElement)) return;
+    if (this.nativeSurface?.element === surface) return;
+    this.restoreNativeTakeover();
+    this.nativeSurface = {
+      element: surface,
+      pointerEvents: surface.style.pointerEvents,
+      ariaHidden: surface.getAttribute("aria-hidden"),
+    };
+    surface.style.pointerEvents = "none";
+    surface.setAttribute("aria-hidden", "true");
+    surface.dataset["cfptTakeover"] = "true";
+  }
+
+  private restoreNativeTakeover(): void {
+    const snapshot = this.nativeSurface;
+    if (!snapshot) return;
+    snapshot.element.style.pointerEvents = snapshot.pointerEvents;
+    if (snapshot.ariaHidden === null) snapshot.element.removeAttribute("aria-hidden");
+    else snapshot.element.setAttribute("aria-hidden", snapshot.ariaHidden);
+    delete snapshot.element.dataset["cfptTakeover"];
+    this.nativeSurface = null;
+  }
+
+  private positionTakeover(): void {
+    const surface = query("composerSurface");
+    if (!(surface instanceof HTMLElement)) return;
+    const rect = surface.getBoundingClientRect();
+    const viewportWidth = Math.max(320, window.innerWidth);
+    const margin = viewportWidth <= 620 ? 8 : 12;
+    const fallbackWidth = Math.min(820, viewportWidth - margin * 2);
+    const width = rect.width >= 280 ? Math.min(rect.width, viewportWidth - margin * 2) : fallbackWidth;
+    const left = rect.width >= 280 ? Math.min(Math.max(margin, rect.left), viewportWidth - width - margin) : (viewportWidth - width) / 2;
+    const bottom = rect.height > 0 ? Math.max(8, window.innerHeight - rect.bottom) : 16;
+    Object.assign(this.panelEl.style, {
+      left: `${Math.round(left)}px`,
+      right: "auto",
+      bottom: `${Math.round(bottom)}px`,
+      top: "auto",
+      width: `${Math.round(width)}px`,
+    });
+  }
+
+  private positionLauncherTip(): void {
+    const rect = this.host.getBoundingClientRect();
+    const width = Math.min(310, window.innerWidth - 24);
+    const left = Math.min(Math.max(12, rect.left - 10), Math.max(12, window.innerWidth - width - 12));
+    const top = rect.top > 175 ? rect.top - 165 : rect.bottom + 10;
+    Object.assign(this.launcherTipEl.style, {
+      left: `${Math.round(left)}px`,
+      right: "auto",
+      top: `${Math.round(Math.max(12, top))}px`,
+      bottom: "auto",
+    });
+  }
+
+  private panelShell(body: string): string {
+    return `
+      <div class="cfpt-panel-head">
+        <strong>Chat FreePT</strong>
+        <button class="cfpt-panel-close" type="button" data-action="close" aria-label="Close Chat FreePT">×</button>
+      </div>
+      <div class="cfpt-body">${body}</div>
+    `;
   }
 
   private bodyHtml(state: RunState, passive: boolean): string {
@@ -300,56 +439,36 @@ export class Panel {
             health.missing.join(", "),
           )}. Auto-run cannot operate until the extension is updated.</div>`
         : "";
-
     if (passive) return warn + this.passiveHtml(state);
     const controls = this.automationControlsHtml(state);
+    return warn + controls + this.statusBodyHtml(state);
+  }
 
+  private statusBodyHtml(state: RunState): string {
     switch (state.status) {
       case "idle":
-        return warn + controls + this.ideaFormHtml(state);
+        return this.ideaFormHtml(state);
       case "inserting":
       case "sending":
       case "streaming":
       case "cooldown":
-        return warn + controls + this.runningHtml(state);
+        return this.runningHtml(state);
       case "awaiting_user":
-        return (
-          warn +
-          controls +
-          (state.phase === "plan_ready" ? this.planReadyHtml(state) : this.needsInputHtml(state))
-        );
+        return state.phase === "plan_ready" ? this.planReadyHtml(state) : this.needsInputHtml(state);
       case "paused":
       case "error":
-        return warn + controls + this.pausedHtml(state);
+        return this.pausedHtml(state);
       case "complete":
-        return warn + controls + this.completeHtml(state);
+        return this.completeHtml(state);
       default:
-        return warn + controls;
+        return "";
     }
   }
 
   private automationControlsHtml(state: RunState): string {
     const enabled = autoContinueEnabled(state);
     const queued = state.queuedUserText?.trim() ?? "";
-    const queueControls = canQueueNext(state)
-      ? `
-        <div class="cfpt-field">
-          ${
-            queued
-              ? `<p class="cfpt-note"><strong>Queued next:</strong> ${esc(queued)}</p>
-                 <button class="cfpt-btn" type="button" data-action="showqueue">Edit queued message</button>
-                 <button class="cfpt-btn" type="button" data-action="clearqueue">Clear queued message</button>`
-              : `<button class="cfpt-btn" type="button" data-action="showqueue">Queue next message</button>`
-          }
-          <div class="cfpt-field cfpt-hidden" data-ref="queue-editor">
-            <label>Next user message</label>
-            <textarea data-ref="queue-next" rows="3" placeholder="Send this instead of the next automatic continue…">${esc(queued)}</textarea>
-            <button class="cfpt-btn cfpt-btn-primary" type="button" data-action="savequeue">Save queued message</button>
-            <button class="cfpt-btn" type="button" data-action="hidequeue">Cancel</button>
-          </div>
-        </div>`
-      : "";
-
+    const queueControls = canQueueNext(state) ? this.queueControlsHtml(queued) : "";
     return `
       <div class="cfpt-field">
         <label class="cfpt-check-row">
@@ -362,11 +481,28 @@ export class Panel {
     `;
   }
 
+  private queueControlsHtml(queued: string): string {
+    const summary = queued
+      ? `<p class="cfpt-note"><strong>Queued next:</strong> ${esc(queued)}</p>
+         <button class="cfpt-btn" type="button" data-action="showqueue">Edit queued message</button>
+         <button class="cfpt-btn" type="button" data-action="clearqueue">Clear queued message</button>`
+      : `<button class="cfpt-btn" type="button" data-action="showqueue">Queue next message</button>`;
+    return `
+      <div class="cfpt-field">
+        ${summary}
+        <div class="cfpt-field cfpt-hidden" data-ref="queue-editor">
+          <label>Next user message</label>
+          <textarea data-ref="queue-next" rows="3" placeholder="Send this instead of the next automatic continue…">${esc(queued)}</textarea>
+          <button class="cfpt-btn cfpt-btn-primary" type="button" data-action="savequeue">Save queued message</button>
+          <button class="cfpt-btn" type="button" data-action="hidequeue">Cancel</button>
+        </div>
+      </div>`;
+  }
+
   private passiveHtml(state: RunState): string {
     return `
       <h3>Active in another tab</h3>
-      <p class="cfpt-note">Another ChatGPT tab currently owns this conversation. This tab is
-      read-only and will take over automatically if the other tab closes or stops responding.</p>
+      <p class="cfpt-note">Another ChatGPT tab currently owns this conversation. This tab is read-only and will take over automatically if the other tab closes or stops responding.</p>
       <p class="cfpt-note">Current state: ${esc(phaseLabel(state.phase))} · ${esc(
         STATUS_LABEL[state.status] ?? state.status,
       )}</p>
@@ -377,36 +513,27 @@ export class Panel {
     return `
       <h3>What should ChatGPT build for you?</h3>
       <div class="cfpt-field">
-        <textarea data-ref="idea" rows="5" placeholder="Describe the project you want built…">${esc(
+        <textarea data-ref="idea" rows="6" placeholder="Describe the project you want built…">${esc(
           state.idea,
         )}</textarea>
       </div>
       <div class="cfpt-radio-row">
-        <label><input type="radio" name="repomode" value="new" ${
-          state.repoMode === "new" ? "checked" : ""
-        }/> New private repo</label>
-        <label><input type="radio" name="repomode" value="existing" ${
-          state.repoMode === "existing" ? "checked" : ""
-        }/> Existing repo</label>
+        <label><input type="radio" name="repomode" value="new" ${state.repoMode === "new" ? "checked" : ""}/> New private repo</label>
+        <label><input type="radio" name="repomode" value="existing" ${state.repoMode === "existing" ? "checked" : ""}/> Existing repo</label>
       </div>
       <div class="cfpt-field">
         <label>Repo name (optional for new; owner/name for existing)</label>
         <input type="text" data-ref="reponame" value="${esc(state.repoName)}" placeholder="e.g. my-idea or owner/my-repo"/>
       </div>
-      <p class="cfpt-note">New private repos generally need GitHub's official remote MCP in
-      ChatGPT Developer Mode because repository and label creation are required. Existing
-      repos can use any GitHub toolset that passes the mode-aware preflight. Chat FreePT
-      never receives your GitHub credentials. <a class="cfpt-link" href="https://chatgpt.com/plugins"
-      target="_blank" rel="noreferrer noopener">Open ChatGPT Plugins</a>.</p>
+      <p class="cfpt-note">Full autonomous GitHub work uses Developer mode + the remote GitHub MCP. Free-plan users can still use Chat FreePT in an assisted workflow, but should prepare an existing repo first and expect manual GitHub steps when ChatGPT lacks write tools.</p>
+      <button class="cfpt-btn" type="button" data-action="setup-open">GitHub setup</button>
       <button class="cfpt-btn cfpt-btn-primary" data-action="start">Start planning</button>
     `;
   }
 
   private runningHtml(state: RunState): string {
     const sendNow =
-      state.status === "cooldown"
-        ? `<button class="cfpt-btn" data-action="sendnow">Send now</button>`
-        : "";
+      state.status === "cooldown" ? `<button class="cfpt-btn" data-action="sendnow">Send now</button>` : "";
     return `
       <div class="cfpt-status-line"><span class="cfpt-spinner"></span>
         <strong data-ref="statusline">${esc(STATUS_LABEL[state.status] ?? state.status)}</strong>
@@ -424,8 +551,7 @@ export class Panel {
       <h3>Master plan ready</h3>
       <p class="cfpt-note">${esc(state.planSummary ?? "Review the plan in the conversation.")}</p>
       ${repoLine(state)}
-      <p class="cfpt-note">Want changes? Just reply in the chat — the plan phase resumes
-      automatically. Happy with it?</p>
+      <p class="cfpt-note">Want changes? Reply in the chat and the plan phase resumes automatically. Happy with it?</p>
       <button class="cfpt-btn cfpt-btn-primary" data-action="startdev">Start development</button>
       <button class="cfpt-btn cfpt-btn-danger" data-action="stop">Stop</button>
     `;
@@ -440,7 +566,7 @@ export class Panel {
         autoPaused
           ? ""
           : `<div class="cfpt-field">
-               <textarea data-ref="reply" rows="3" placeholder="Type your answer…"></textarea>
+               <textarea data-ref="reply" rows="4" placeholder="Type your answer…"></textarea>
              </div>
              <button class="cfpt-btn cfpt-btn-primary" data-action="reply">Send reply</button>
              <button class="cfpt-btn" data-action="resume">I answered in the chat — resume</button>`
@@ -496,8 +622,9 @@ export class Panel {
     if (statusLine) statusLine.textContent = STATUS_LABEL[state.status] ?? state.status;
   }
 
-  private onClick(e: Event): void {
-    const target = (e.target as HTMLElement).closest("[data-action]") as HTMLElement | null;
+  private onClick(event: Event): void {
+    event.stopPropagation();
+    const target = (event.target as HTMLElement).closest<HTMLElement>("[data-action]");
     if (!target) return;
     switch (target.dataset["action"]) {
       case "close":
@@ -550,6 +677,16 @@ export class Panel {
         break;
       case "tip-continue":
         void this.acknowledgeLauncherTip(this.tipCheckboxChecked());
+        break;
+      case "setup-open":
+      case "setup-back":
+        this.showSetupModal();
+        break;
+      case "free-setup":
+        this.showSetupModal("free");
+        break;
+      case "setup-guide":
+        void this.startSetupGuide();
         break;
       case "setup-done":
         void this.acknowledgeSetup();
@@ -614,7 +751,9 @@ export class Panel {
 
   private refValue(ref: string): string {
     const el = this.panelEl.querySelector(`[data-ref="${ref}"]`) as
-      HTMLTextAreaElement | HTMLInputElement | null;
+      | HTMLTextAreaElement
+      | HTMLInputElement
+      | null;
     return el?.value ?? "";
   }
 
@@ -624,6 +763,71 @@ export class Panel {
     ) as HTMLInputElement | null;
     return el?.value ?? "";
   }
+}
+
+function appendStyle(root: ShadowRoot): void {
+  const style = document.createElement("style");
+  style.textContent = PANEL_CSS;
+  root.appendChild(style);
+}
+
+function airplaneSvg(): string {
+  return `
+    <svg class="cfpt-airplane" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 2.5c-.8 0-1.4.6-1.4 1.4v5.3L3 13.8v2l7.6-2.4v4.2l-2.3 1.7v1.4l3.7-1.1 3.7 1.1v-1.4l-2.3-1.7v-4.2l7.6 2.4v-2l-7.6-4.6V3.9c0-.8-.6-1.4-1.4-1.4Z"></path>
+    </svg>`;
+}
+
+function launcherTipHtml(): string {
+  return `
+    <button class="cfpt-icon-close" type="button" data-action="tip-continue" aria-label="Dismiss launcher tip">×</button>
+    <strong>Chat FreePT lives here</strong>
+    <p>The airplane sits beside ChatGPT's + button. Open it whenever you want Chat FreePT to take over the composer.</p>
+    <label class="cfpt-check-row">
+      <input type="checkbox" data-ref="suppress-launcher-tip" />
+      <span>Don't show this tip again</span>
+    </label>
+    <button class="cfpt-btn cfpt-btn-primary cfpt-toast-continue" type="button" data-action="tip-continue">Continue</button>`;
+}
+
+function paidSetupHtml(): string {
+  return `
+    <section class="cfpt-setup-card" role="dialog" aria-modal="true" aria-labelledby="cfpt-setup-title">
+      <button class="cfpt-icon-close" type="button" data-action="setup-done" aria-label="Close setup">×</button>
+      <div class="cfpt-setup-icon" aria-hidden="true">${airplaneSvg()}</div>
+      <div class="cfpt-plan-badge">Paid plan · full GitHub automation</div>
+      <h2 id="cfpt-setup-title">Connect GitHub with a follow-along guide</h2>
+      <p class="cfpt-setup-lead">For full autonomous repository work, Chat FreePT needs ChatGPT's Developer mode and a custom GitHub MCP/plugin with the write permissions you approve. ChatGPT marks Developer mode as Elevated Risk because unverified connectors can modify data.</p>
+      <p class="cfpt-setup-lead">The guide opens Settings for you and highlights one live ChatGPT control at a time: Security and login → Developer mode → Plugins → + → GitHub MCP URL → OAuth → Create → add GitHub MCP to this chat.</p>
+      <div class="cfpt-setup-actions">
+        <button class="cfpt-btn" type="button" data-action="free-setup">Using ChatGPT Free?</button>
+        <button class="cfpt-btn" type="button" data-action="setup-done">I'll set it up myself</button>
+        <button class="cfpt-btn cfpt-btn-primary" type="button" data-action="setup-guide">Follow along</button>
+      </div>
+    </section>`;
+}
+
+function freeSetupHtml(): string {
+  return `
+    <section class="cfpt-setup-card" role="dialog" aria-modal="true" aria-labelledby="cfpt-free-title">
+      <button class="cfpt-icon-close" type="button" data-action="setup-done" aria-label="Close setup">×</button>
+      <div class="cfpt-plan-badge">ChatGPT Free · assisted GitHub workflow</div>
+      <h2 id="cfpt-free-title">Prepare GitHub manually first</h2>
+      <p class="cfpt-setup-lead">Chat FreePT's local planning, continuation, queueing, pause, and NEEDS_INPUT flow still works on Free. The limitation is the full custom-MCP/Developer-mode path, so repository actions may need you.</p>
+      <ol class="cfpt-setup-steps">
+        <li>Create the target GitHub repository yourself before starting Chat FreePT.</li>
+        <li>Make sure <strong>main</strong> exists and create <strong>dev</strong> from the same starting commit.</li>
+        <li>In Chat FreePT choose <strong>Existing repo</strong> and enter <code>owner/repo</code>; do not rely on New private repo creation.</li>
+        <li>Enable whatever GitHub/plugin access your ChatGPT account currently exposes. If no write tool is available, keep GitHub open separately.</li>
+        <li>When ChatGPT cannot create a branch/file, Issue/label, PR, merge, or inspect CI, it should stop with <strong>NEEDS_INPUT</strong>. Perform only that requested GitHub step manually, return to the chat, and Resume.</li>
+        <li>Because those writes are manual, Free mode is assisted rather than fully autonomous; never treat a missing/zero CI result as green.</li>
+      </ol>
+      <p class="cfpt-setup-footnote">Chat FreePT does not receive your GitHub password or token. Workspace policy and ChatGPT feature availability can vary by account.</p>
+      <div class="cfpt-setup-actions">
+        <button class="cfpt-btn" type="button" data-action="setup-back">Back</button>
+        <button class="cfpt-btn cfpt-btn-primary" type="button" data-action="setup-done">I understand</button>
+      </div>
+    </section>`;
 }
 
 function phaseLabel(phase: string): string {

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -23,6 +23,12 @@ interface StoredGuide {
   returnUrl: string;
 }
 
+interface GuideCopy {
+  title: string;
+  body: string;
+  actions: string;
+}
+
 const STORAGE_KEY = "cfpt:setup-guide:v1";
 const MCP_URL = "https://api.githubcopilot.com/mcp/";
 const PLUGINS_URL = "https://chatgpt.com/plugins";
@@ -112,6 +118,17 @@ const TARGETS: Partial<Record<SetupGuideStep, GuideTargetId>> = {
   "developer-menu": "conversationDeveloperMode",
   "github-app": "conversationGitHubMcp",
 };
+
+const EARLY_COPY_STEPS = new Set<SetupGuideStep>([
+  "security",
+  "developer",
+  "developer-toggle",
+  "plugins",
+  "plugin-add",
+  "plugin-name",
+  "plugin-server",
+  "plugin-auth",
+]);
 
 export class SetupGuide {
   private readonly host: HTMLDivElement;
@@ -218,7 +235,9 @@ export class SetupGuide {
 
   private currentTarget(): HTMLElement | null {
     if (this.step === "developer-menu") {
-      return queryGuideTarget("conversationDeveloperMode") ?? queryGuideTarget("conversationGitHubMcp");
+      return (
+        queryGuideTarget("conversationDeveloperMode") ?? queryGuideTarget("conversationGitHubMcp")
+      );
     }
     const id = TARGETS[this.step];
     return id ? queryGuideTarget(id) : null;
@@ -272,7 +291,10 @@ export class SetupGuide {
 
     const rect = target.getBoundingClientRect();
     const width = Math.min(340, window.innerWidth - 24);
-    const left = Math.min(Math.max(12, rect.left), Math.max(12, window.innerWidth - width - 12));
+    const left = Math.min(
+      Math.max(12, rect.left),
+      Math.max(12, window.innerWidth - width - 12),
+    );
     const roomBelow = window.innerHeight - rect.bottom;
     const top = roomBelow > 210 ? rect.bottom + 12 : Math.max(12, rect.top - 190);
     Object.assign(this.card.style, {
@@ -287,7 +309,9 @@ export class SetupGuide {
     if (this.lastScrolledStep === this.step) return;
     if (this.step !== "developer" && this.step !== "developer-toggle") return;
     this.lastScrolledStep = this.step;
-    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    if (typeof target.scrollIntoView === "function") {
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
   }
 
   private afterTargetClick(target: HTMLElement): void {
@@ -343,9 +367,11 @@ export class SetupGuide {
     if (action === "cancel") void this.cancel();
     else if (action === "developer-next") void this.setStep("developer-toggle");
     else if (action === "open-plugins") this.openPlugins();
-    else if (action === "fill-name") this.fillField("pluginNameInput", "GitHub MCP", "plugin-server");
-    else if (action === "fill-url") this.fillField("pluginServerInput", MCP_URL, "plugin-auth");
-    else if (action === "auth-next") void this.setStep("plugin-risk");
+    else if (action === "fill-name") {
+      this.fillField("pluginNameInput", "GitHub MCP", "plugin-server");
+    } else if (action === "fill-url") {
+      this.fillField("pluginServerInput", MCP_URL, "plugin-auth");
+    } else if (action === "auth-next") void this.setStep("plugin-risk");
     else if (action === "risk-next") this.advanceRisk();
     else if (action === "return-chat") this.returnToChat();
     else if (action === "finish") void this.finish();
@@ -389,11 +415,18 @@ export class SetupGuide {
   }
 }
 
-function guideCopy(step: SetupGuideStep, found: boolean): { title: string; body: string; actions: string } {
+function guideCopy(step: SetupGuideStep, found: boolean): GuideCopy {
   const wait = found ? "" : " I’m waiting for this ChatGPT control to appear.";
+  return EARLY_COPY_STEPS.has(step) ? guideCopyEarly(step, wait) : guideCopyLate(step, wait);
+}
+
+function guideCopyEarly(step: SetupGuideStep, wait: string): GuideCopy {
   switch (step) {
     case "security":
-      return copy("1 · Security and login", `Click the highlighted <b>Security and login</b> item.${wait}`);
+      return copy(
+        "1 · Security and login",
+        `Click the highlighted <b>Security and login</b> item.${wait}`,
+      );
     case "developer":
       return copy(
         "2 · Developer mode",
@@ -401,7 +434,10 @@ function guideCopy(step: SetupGuideStep, found: boolean): { title: string; body:
         primary("developer-next", "Show the switch"),
       );
     case "developer-toggle":
-      return copy("3 · Enable Developer mode", `Turn on the highlighted <b>Developer mode</b> switch. ChatGPT labels this Elevated Risk because it permits unverified connectors.${wait}`);
+      return copy(
+        "3 · Enable Developer mode",
+        `Turn on the highlighted <b>Developer mode</b> switch. ChatGPT labels this Elevated Risk because it permits unverified connectors.${wait}`,
+      );
     case "plugins":
       return copy(
         "4 · Open Plugins",
@@ -428,6 +464,13 @@ function guideCopy(step: SetupGuideStep, found: boolean): { title: string; body:
         `Set Authentication to <b>OAuth</b> in the highlighted control.${wait}`,
         primary("auth-next", "OAuth selected — next"),
       );
+    default:
+      return guideCopyLate(step, wait);
+  }
+}
+
+function guideCopyLate(step: SetupGuideStep, wait: string): GuideCopy {
+  switch (step) {
     case "plugin-risk":
       return copy(
         "9 · Risk acknowledgement",
@@ -443,22 +486,37 @@ function guideCopy(step: SetupGuideStep, found: boolean): { title: string; body:
         primary("return-chat", "Connected — return to chat"),
       );
     case "chat-plus":
-      return copy("12 · Add it to this chat", `Click the highlighted <b>+</b> beside the composer.${wait}`);
+      return copy(
+        "12 · Add it to this chat",
+        `Click the highlighted <b>+</b> beside the composer.${wait}`,
+      );
     case "developer-menu":
-      return copy("13 · Developer mode", `Choose the highlighted <b>Developer mode</b> entry. If GitHub MCP appears directly, choose it instead.${wait}`);
+      return copy(
+        "13 · Developer mode",
+        `Choose the highlighted <b>Developer mode</b> entry. If GitHub MCP appears directly, choose it instead.${wait}`,
+      );
     case "github-app":
-      return copy("14 · GitHub MCP", `Choose the highlighted <b>GitHub MCP</b> plugin for this conversation.${wait}`);
+      return copy(
+        "14 · GitHub MCP",
+        `Choose the highlighted <b>GitHub MCP</b> plugin for this conversation.${wait}`,
+      );
     case "done":
       return copy(
         "Setup complete",
         "Chat FreePT can now run its GitHub capability preflight in this conversation.",
         primary("finish", "Done"),
       );
+    default:
+      return copy("Setup", `Continue with the highlighted ChatGPT control.${wait}`);
   }
 }
 
-function copy(title: string, body: string, actions = ""): { title: string; body: string; actions: string } {
-  return { title, body, actions: actions ? `<div class="cfpt-guide-actions">${actions}</div>` : "" };
+function copy(title: string, body: string, actions = ""): GuideCopy {
+  return {
+    title,
+    body,
+    actions: actions ? `<div class="cfpt-guide-actions">${actions}</div>` : "",
+  };
 }
 
 function primary(action: string, label: string): string {
@@ -473,11 +531,15 @@ function isGuideStep(value: unknown): value is SetupGuideStep {
 
 function isControlEnabled(element: HTMLElement): boolean {
   if (element instanceof HTMLInputElement) return element.checked;
-  return element.getAttribute("aria-checked") === "true" || element.getAttribute("data-state") === "checked";
+  return (
+    element.getAttribute("aria-checked") === "true" ||
+    element.getAttribute("data-state") === "checked"
+  );
 }
 
 function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
-  const prototype = element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+  const prototype =
+    element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
   const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
   if (setter) setter.call(element, value);
   else element.value = value;

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -291,10 +291,7 @@ export class SetupGuide {
 
     const rect = target.getBoundingClientRect();
     const width = Math.min(340, window.innerWidth - 24);
-    const left = Math.min(
-      Math.max(12, rect.left),
-      Math.max(12, window.innerWidth - width - 12),
-    );
+    const left = Math.min(Math.max(12, rect.left), Math.max(12, window.innerWidth - width - 12));
     const roomBelow = window.innerHeight - rect.bottom;
     const top = roomBelow > 210 ? rect.bottom + 12 : Math.max(12, rect.top - 190);
     Object.assign(this.card.style, {
@@ -539,7 +536,9 @@ function isControlEnabled(element: HTMLElement): boolean {
 
 function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
   const prototype =
-    element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+    element instanceof HTMLInputElement
+      ? HTMLInputElement.prototype
+      : HTMLTextAreaElement.prototype;
   const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
   if (setter) setter.call(element, value);
   else element.value = value;

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -1,0 +1,508 @@
+import { queryGuideTarget, type GuideTargetId } from "../selectors";
+
+export type SetupGuideStep =
+  | "security"
+  | "developer"
+  | "developer-toggle"
+  | "plugins"
+  | "plugin-add"
+  | "plugin-name"
+  | "plugin-server"
+  | "plugin-auth"
+  | "plugin-risk"
+  | "plugin-create"
+  | "oauth"
+  | "chat-plus"
+  | "developer-menu"
+  | "github-app"
+  | "done";
+
+interface StoredGuide {
+  active: boolean;
+  step: SetupGuideStep;
+  returnUrl: string;
+}
+
+const STORAGE_KEY = "cfpt:setup-guide:v1";
+const MCP_URL = "https://api.githubcopilot.com/mcp/";
+const PLUGINS_URL = "https://chatgpt.com/plugins";
+
+const GUIDE_CSS = `
+:host {
+  all: initial;
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2147483647;
+  color-scheme: inherit;
+  --surface: color-mix(in srgb, Canvas 92%, transparent);
+  --text: CanvasText;
+  --muted: color-mix(in srgb, CanvasText 65%, transparent);
+  --border: color-mix(in srgb, CanvasText 18%, transparent);
+  --accent: #10a37f;
+}
+* { box-sizing: border-box; font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+.cfpt-guide-hidden { display: none !important; }
+.cfpt-guide-ring {
+  position: fixed;
+  pointer-events: none;
+  border: 3px solid var(--accent);
+  border-radius: 12px;
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--accent) 18%, transparent), 0 0 0 9999px rgba(0, 0, 0, 0.12);
+  transition: left 120ms ease, top 120ms ease, width 120ms ease, height 120ms ease;
+}
+.cfpt-guide-card {
+  position: fixed;
+  pointer-events: auto;
+  width: min(340px, calc(100vw - 24px));
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 18px 55px rgba(0, 0, 0, 0.26);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  font-size: 13px;
+  line-height: 1.45;
+}
+.cfpt-guide-card strong { display: block; margin-right: 24px; font-size: 14px; }
+.cfpt-guide-card p { margin: 7px 0 0; color: var(--muted); }
+.cfpt-guide-card code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; overflow-wrap: anywhere; }
+.cfpt-guide-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 11px; }
+.cfpt-guide-btn {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 7px 11px;
+  background: color-mix(in srgb, CanvasText 7%, transparent);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+}
+.cfpt-guide-btn-primary { background: var(--accent); color: white; border-color: transparent; }
+.cfpt-guide-close {
+  position: absolute;
+  inset-inline-end: 8px;
+  top: 7px;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 19px;
+}
+.cfpt-guide-close:hover { background: color-mix(in srgb, CanvasText 8%, transparent); color: var(--text); }
+@media (prefers-reduced-motion: reduce) { .cfpt-guide-ring { transition: none; } }
+`;
+
+const TARGETS: Partial<Record<SetupGuideStep, GuideTargetId>> = {
+  security: "settingsSecurity",
+  developer: "developerModeRow",
+  "developer-toggle": "developerModeToggle",
+  "plugin-add": "pluginAddButton",
+  "plugin-name": "pluginNameInput",
+  "plugin-server": "pluginServerInput",
+  "plugin-auth": "pluginAuthControl",
+  "plugin-risk": "pluginRiskCheckbox",
+  "plugin-create": "pluginCreateButton",
+  "chat-plus": "composerPlusButton",
+  "developer-menu": "conversationDeveloperMode",
+  "github-app": "conversationGitHubMcp",
+};
+
+export class SetupGuide {
+  private readonly host: HTMLDivElement;
+  private readonly shadow: ShadowRoot;
+  private readonly ring: HTMLDivElement;
+  private readonly card: HTMLDivElement;
+  private readonly observer: MutationObserver;
+  private active = false;
+  private step: SetupGuideStep = "security";
+  private returnUrl = "https://chatgpt.com/";
+  private lastScrolledStep: SetupGuideStep | null = null;
+  private disposed = false;
+
+  constructor() {
+    this.host = document.createElement("div");
+    this.host.id = "cfpt-setup-guide-root";
+    this.shadow = this.host.attachShadow({ mode: "closed" });
+    const style = document.createElement("style");
+    style.textContent = GUIDE_CSS;
+    this.shadow.appendChild(style);
+
+    this.ring = document.createElement("div");
+    this.ring.className = "cfpt-guide-ring cfpt-guide-hidden";
+    this.shadow.appendChild(this.ring);
+
+    this.card = document.createElement("div");
+    this.card.className = "cfpt-guide-card cfpt-guide-hidden";
+    this.card.setAttribute("role", "dialog");
+    this.card.setAttribute("aria-live", "polite");
+    this.shadow.appendChild(this.card);
+
+    document.body.appendChild(this.host);
+    this.shadow.addEventListener("click", (event) => this.onGuideClick(event));
+    document.addEventListener("click", this.onPageClick, true);
+    window.addEventListener("resize", this.onViewportChange);
+    window.addEventListener("scroll", this.onViewportChange, true);
+    this.observer = new MutationObserver(() => this.render());
+    this.observer.observe(document.documentElement, { childList: true, subtree: true });
+    void this.restore();
+  }
+
+  async start(): Promise<void> {
+    this.active = true;
+    this.step = "security";
+    this.returnUrl = chatReturnUrl();
+    this.lastScrolledStep = null;
+    await this.persist();
+    this.render();
+    openSettings();
+  }
+
+  async cancel(): Promise<void> {
+    this.active = false;
+    this.hide();
+    await this.persist();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.observer.disconnect();
+    document.removeEventListener("click", this.onPageClick, true);
+    window.removeEventListener("resize", this.onViewportChange);
+    window.removeEventListener("scroll", this.onViewportChange, true);
+    this.host.remove();
+  }
+
+  private readonly onViewportChange = (): void => this.render();
+
+  private readonly onPageClick = (event: Event): void => {
+    if (!this.active) return;
+    const target = this.currentTarget();
+    const clicked = event.target instanceof Node ? event.target : null;
+    if (!target || !clicked || !target.contains(clicked)) return;
+    this.afterTargetClick(target);
+  };
+
+  private async restore(): Promise<void> {
+    try {
+      const stored = await chrome.storage.local.get(STORAGE_KEY);
+      const value = stored[STORAGE_KEY] as Partial<StoredGuide> | undefined;
+      if (value?.active === true && isGuideStep(value.step)) {
+        this.active = true;
+        this.step = value.step;
+        this.returnUrl = typeof value.returnUrl === "string" ? value.returnUrl : chatReturnUrl();
+      }
+    } catch {
+      this.active = false;
+    }
+    if (!this.disposed) this.render();
+  }
+
+  private async persist(): Promise<void> {
+    try {
+      const value: StoredGuide = {
+        active: this.active,
+        step: this.step,
+        returnUrl: this.returnUrl,
+      };
+      await chrome.storage.local.set({ [STORAGE_KEY]: value });
+    } catch {
+      // The guide remains usable for the current page even if persistence is unavailable.
+    }
+  }
+
+  private currentTarget(): HTMLElement | null {
+    if (this.step === "developer-menu") {
+      return queryGuideTarget("conversationDeveloperMode") ?? queryGuideTarget("conversationGitHubMcp");
+    }
+    const id = TARGETS[this.step];
+    return id ? queryGuideTarget(id) : null;
+  }
+
+  private render(): void {
+    if (!this.active || this.disposed) {
+      this.hide();
+      return;
+    }
+
+    const target = this.currentTarget();
+    if (target) {
+      this.positionRing(target);
+      this.maybeScrollTarget(target);
+    } else {
+      this.ring.classList.add("cfpt-guide-hidden");
+    }
+    this.card.innerHTML = this.cardHtml(Boolean(target));
+    this.card.classList.remove("cfpt-guide-hidden");
+    this.positionCard(target);
+  }
+
+  private hide(): void {
+    this.ring.classList.add("cfpt-guide-hidden");
+    this.card.classList.add("cfpt-guide-hidden");
+  }
+
+  private positionRing(target: HTMLElement): void {
+    const rect = target.getBoundingClientRect();
+    const pad = 5;
+    Object.assign(this.ring.style, {
+      left: `${Math.max(4, rect.left - pad)}px`,
+      top: `${Math.max(4, rect.top - pad)}px`,
+      width: `${Math.max(24, rect.width + pad * 2)}px`,
+      height: `${Math.max(24, rect.height + pad * 2)}px`,
+    });
+    this.ring.classList.remove("cfpt-guide-hidden");
+  }
+
+  private positionCard(target: HTMLElement | null): void {
+    if (!target) {
+      Object.assign(this.card.style, {
+        left: "auto",
+        right: "18px",
+        top: "auto",
+        bottom: "18px",
+      });
+      return;
+    }
+
+    const rect = target.getBoundingClientRect();
+    const width = Math.min(340, window.innerWidth - 24);
+    const left = Math.min(Math.max(12, rect.left), Math.max(12, window.innerWidth - width - 12));
+    const roomBelow = window.innerHeight - rect.bottom;
+    const top = roomBelow > 210 ? rect.bottom + 12 : Math.max(12, rect.top - 190);
+    Object.assign(this.card.style, {
+      left: `${left}px`,
+      right: "auto",
+      top: `${top}px`,
+      bottom: "auto",
+    });
+  }
+
+  private maybeScrollTarget(target: HTMLElement): void {
+    if (this.lastScrolledStep === this.step) return;
+    if (this.step !== "developer" && this.step !== "developer-toggle") return;
+    this.lastScrolledStep = this.step;
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+
+  private afterTargetClick(target: HTMLElement): void {
+    switch (this.step) {
+      case "security":
+        this.deferStep("developer");
+        break;
+      case "developer-toggle":
+        setTimeout(() => {
+          if (isControlEnabled(target)) void this.setStep("plugins");
+        }, 120);
+        break;
+      case "plugin-add":
+        this.deferStep("plugin-name");
+        break;
+      case "plugin-risk":
+        setTimeout(() => {
+          if (isControlEnabled(target)) void this.setStep("plugin-create");
+        }, 80);
+        break;
+      case "plugin-create":
+        this.deferStep("oauth");
+        break;
+      case "chat-plus":
+        this.deferStep("developer-menu");
+        break;
+      case "developer-menu":
+        if (target === queryGuideTarget("conversationGitHubMcp")) this.deferStep("done");
+        else this.deferStep("github-app");
+        break;
+      case "github-app":
+        this.deferStep("done");
+        break;
+    }
+  }
+
+  private deferStep(step: SetupGuideStep): void {
+    setTimeout(() => void this.setStep(step), 80);
+  }
+
+  private async setStep(step: SetupGuideStep): Promise<void> {
+    this.step = step;
+    this.lastScrolledStep = null;
+    await this.persist();
+    this.render();
+  }
+
+  private onGuideClick(event: Event): void {
+    const target = (event.target as HTMLElement).closest<HTMLElement>("[data-guide-action]");
+    if (!target) return;
+    event.stopPropagation();
+    const action = target.dataset["guideAction"];
+    if (action === "cancel") void this.cancel();
+    else if (action === "developer-next") void this.setStep("developer-toggle");
+    else if (action === "open-plugins") this.openPlugins();
+    else if (action === "fill-name") this.fillField("pluginNameInput", "GitHub MCP", "plugin-server");
+    else if (action === "fill-url") this.fillField("pluginServerInput", MCP_URL, "plugin-auth");
+    else if (action === "auth-next") void this.setStep("plugin-risk");
+    else if (action === "risk-next") this.advanceRisk();
+    else if (action === "return-chat") this.returnToChat();
+    else if (action === "finish") void this.finish();
+  }
+
+  private openPlugins(): void {
+    void this.setStep("plugin-add").then(() => navigate(PLUGINS_URL));
+  }
+
+  private fillField(id: GuideTargetId, value: string, next: SetupGuideStep): void {
+    const field = queryGuideTarget(id);
+    if (!(field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement)) return;
+    setNativeValue(field, value);
+    void this.setStep(next);
+  }
+
+  private advanceRisk(): void {
+    const checkbox = queryGuideTarget("pluginRiskCheckbox");
+    if (checkbox && isControlEnabled(checkbox)) void this.setStep("plugin-create");
+  }
+
+  private returnToChat(): void {
+    void this.setStep("chat-plus").then(() => navigate(this.returnUrl));
+  }
+
+  private async finish(): Promise<void> {
+    this.step = "done";
+    this.active = false;
+    await this.persist();
+    this.hide();
+  }
+
+  private cardHtml(found: boolean): string {
+    const content = guideCopy(this.step, found);
+    return `
+      <button class="cfpt-guide-close" type="button" data-guide-action="cancel" aria-label="Stop setup guide">×</button>
+      <strong>${content.title}</strong>
+      <p>${content.body}</p>
+      ${content.actions}
+    `;
+  }
+}
+
+function guideCopy(step: SetupGuideStep, found: boolean): { title: string; body: string; actions: string } {
+  const wait = found ? "" : " I’m waiting for this ChatGPT control to appear.";
+  switch (step) {
+    case "security":
+      return copy("1 · Security and login", `Click the highlighted <b>Security and login</b> item.${wait}`);
+    case "developer":
+      return copy(
+        "2 · Developer mode",
+        `Developer mode is lower on this page. I’ve brought the highlighted row into view.${wait}`,
+        primary("developer-next", "Show the switch"),
+      );
+    case "developer-toggle":
+      return copy("3 · Enable Developer mode", `Turn on the highlighted <b>Developer mode</b> switch. ChatGPT labels this Elevated Risk because it permits unverified connectors.${wait}`);
+    case "plugins":
+      return copy(
+        "4 · Open Plugins",
+        "Developer mode is on. Continue to ChatGPT Plugins to add the official remote GitHub MCP endpoint.",
+        primary("open-plugins", "Open Plugins"),
+      );
+    case "plugin-add":
+      return copy("5 · Add a plugin", `Click the highlighted <b>+</b> button.${wait}`);
+    case "plugin-name":
+      return copy(
+        "6 · Name",
+        `Use <b>GitHub MCP</b> so it is easy to recognize later.${wait}`,
+        primary("fill-name", "Use GitHub MCP"),
+      );
+    case "plugin-server":
+      return copy(
+        "7 · Server URL",
+        `Put <code>${MCP_URL}</code> in the highlighted Server URL field.${wait}`,
+        primary("fill-url", "Fill server URL"),
+      );
+    case "plugin-auth":
+      return copy(
+        "8 · Authentication",
+        `Set Authentication to <b>OAuth</b> in the highlighted control.${wait}`,
+        primary("auth-next", "OAuth selected — next"),
+      );
+    case "plugin-risk":
+      return copy(
+        "9 · Risk acknowledgement",
+        `Read the warning, then check the highlighted acknowledgement.${wait}`,
+        primary("risk-next", "Checked — next"),
+      );
+    case "plugin-create":
+      return copy("10 · Create", `Click the highlighted <b>Create</b> button.${wait}`);
+    case "oauth":
+      return copy(
+        "11 · Complete GitHub OAuth",
+        "Finish the GitHub authorization ChatGPT opens. Approve the repository and workflow write permissions you intend Chat FreePT to use, then return here.",
+        primary("return-chat", "Connected — return to chat"),
+      );
+    case "chat-plus":
+      return copy("12 · Add it to this chat", `Click the highlighted <b>+</b> beside the composer.${wait}`);
+    case "developer-menu":
+      return copy("13 · Developer mode", `Choose the highlighted <b>Developer mode</b> entry. If GitHub MCP appears directly, choose it instead.${wait}`);
+    case "github-app":
+      return copy("14 · GitHub MCP", `Choose the highlighted <b>GitHub MCP</b> plugin for this conversation.${wait}`);
+    case "done":
+      return copy(
+        "Setup complete",
+        "Chat FreePT can now run its GitHub capability preflight in this conversation.",
+        primary("finish", "Done"),
+      );
+  }
+}
+
+function copy(title: string, body: string, actions = ""): { title: string; body: string; actions: string } {
+  return { title, body, actions: actions ? `<div class="cfpt-guide-actions">${actions}</div>` : "" };
+}
+
+function primary(action: string, label: string): string {
+  return `<button class="cfpt-guide-btn cfpt-guide-btn-primary" type="button" data-guide-action="${action}">${label}</button>`;
+}
+
+function isGuideStep(value: unknown): value is SetupGuideStep {
+  return typeof value === "string" && Object.prototype.hasOwnProperty.call(TARGETS, value)
+    ? true
+    : value === "plugins" || value === "oauth" || value === "done";
+}
+
+function isControlEnabled(element: HTMLElement): boolean {
+  if (element instanceof HTMLInputElement) return element.checked;
+  return element.getAttribute("aria-checked") === "true" || element.getAttribute("data-state") === "checked";
+}
+
+function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+  const prototype = element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+  if (setter) setter.call(element, value);
+  else element.value = value;
+  element.dispatchEvent(new Event("input", { bubbles: true }));
+  element.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function chatReturnUrl(): string {
+  const current = window.location.href;
+  if (current.includes("/plugins") || current.includes("#settings")) return "https://chatgpt.com/";
+  return current;
+}
+
+function openSettings(): void {
+  if (window.location.origin === "https://chatgpt.com") {
+    window.location.hash = "#settings";
+    return;
+  }
+  navigate("https://chatgpt.com/#settings");
+}
+
+function navigate(url: string): void {
+  try {
+    window.location.assign(url);
+  } catch {
+    // JSDOM/test environments do not implement navigation; the persisted step still survives.
+  }
+}

--- a/src/content/ui/styles.ts
+++ b/src/content/ui/styles.ts
@@ -1,57 +1,66 @@
 export const PANEL_CSS = `
 :host {
   all: initial;
-  position: absolute;
-  inset-inline-end: 52px;
-  bottom: 8px;
-  width: 34px;
-  height: 34px;
-  display: block;
-  pointer-events: none;
-  z-index: 2147482000;
   color-scheme: inherit;
-  --cfpt-surface: var(--composer-surface-primary, Canvas);
-  --cfpt-text: var(--token-text-primary, CanvasText);
+  --cfpt-surface: var(--cfpt-native-surface, var(--composer-surface-primary, Canvas));
+  --cfpt-text: var(--cfpt-native-text, var(--token-text-primary, CanvasText));
   --cfpt-muted: var(--token-text-secondary, color-mix(in srgb, CanvasText 65%, transparent));
   --cfpt-border: var(--token-border-light, color-mix(in srgb, CanvasText 16%, transparent));
   --cfpt-hover: var(--token-surface-hover, color-mix(in srgb, CanvasText 8%, transparent));
   --cfpt-accent: var(--theme-submit-btn-bg, #10a37f);
 }
+:host([data-cfpt-host="launcher"]) {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  margin: 0;
+  padding: 0;
+  pointer-events: auto;
+  z-index: 2147482000;
+}
+:host([data-cfpt-host="launcher"][data-fallback="true"]) {
+  position: absolute;
+  inset-inline-start: 52px;
+  bottom: 8px;
+}
+:host([data-cfpt-host="overlay"]) {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  display: block;
+  pointer-events: none;
+  z-index: 2147483646;
+}
 * {
   box-sizing: border-box;
   font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
-button, textarea, input { font: inherit; }
+button, textarea, input, select { font: inherit; }
 .cfpt-hidden { display: none !important; }
 .cfpt-launcher {
-  pointer-events: auto;
-  width: 34px;
-  height: 34px;
+  width: 36px;
+  height: 36px;
   display: grid;
   place-items: center;
   border: 0;
   border-radius: 999px;
   padding: 0;
+  margin: 0;
   background: transparent;
   color: var(--cfpt-muted);
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
 }
-.cfpt-launcher:hover {
-  background: var(--cfpt-hover);
-  color: var(--cfpt-text);
-}
+.cfpt-launcher:hover { background: var(--cfpt-hover); color: var(--cfpt-text); }
 .cfpt-launcher:active { transform: scale(0.95); }
-.cfpt-launcher:focus-visible {
-  outline: 2px solid var(--cfpt-accent);
-  outline-offset: 2px;
-}
-.cfpt-airplane {
-  width: 18px;
-  height: 18px;
-  display: block;
-  fill: currentColor;
-}
+.cfpt-launcher:focus-visible { outline: 2px solid var(--cfpt-accent); outline-offset: 2px; }
+.cfpt-airplane { width: 18px; height: 18px; display: block; fill: currentColor; }
 .cfpt-launcher[data-state="run"] {
   color: var(--cfpt-accent);
   animation: cfpt-launcher-pulse 1.6s ease-in-out infinite;
@@ -77,24 +86,56 @@ button, textarea, input { font: inherit; }
     box-shadow: 0 0 0 8px color-mix(in srgb, var(--cfpt-accent) 8%, transparent);
   }
 }
-.cfpt-panel {
+.cfpt-takeover-backdrop {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
   pointer-events: auto;
-  position: absolute;
-  inset-inline-end: 0;
-  bottom: 44px;
-  width: min(390px, calc(100vw - 24px));
-  max-height: min(62vh, 560px);
+  background: rgba(0, 0, 0, 0.045);
+}
+.cfpt-panel {
+  position: fixed;
+  pointer-events: auto;
   display: flex;
   flex-direction: column;
-  background: var(--cfpt-surface);
+  min-height: min(360px, 56vh);
+  max-height: min(72vh, 720px);
   color: var(--cfpt-text);
-  border: 1px solid var(--cfpt-border);
-  border-radius: 18px;
-  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.2);
+  background: color-mix(in srgb, var(--cfpt-surface) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--cfpt-border) 80%, transparent);
+  border-radius: 28px;
+  box-shadow: 0 24px 72px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(22px) saturate(1.12);
+  -webkit-backdrop-filter: blur(22px) saturate(1.12);
   overflow: hidden;
 }
-.cfpt-body { padding: 14px; overflow-y: auto; font-size: 13px; line-height: 1.45; }
-.cfpt-body h3 { margin: 0 0 8px; color: var(--cfpt-text); font-size: 13px; }
+.cfpt-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 48px;
+  padding: 9px 12px 7px 16px;
+  border-bottom: 1px solid color-mix(in srgb, var(--cfpt-border) 70%, transparent);
+}
+.cfpt-panel-head strong { font-size: 13px; letter-spacing: 0.01em; }
+.cfpt-panel-close {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--cfpt-muted);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+.cfpt-panel-close:hover { background: var(--cfpt-hover); color: var(--cfpt-text); }
+.cfpt-body { flex: 1 1 auto; min-height: 0; padding: 16px 18px 18px; overflow-y: auto; font-size: 13px; line-height: 1.45; }
+.cfpt-body h3 { margin: 0 0 8px; color: var(--cfpt-text); font-size: 14px; }
 .cfpt-warn {
   background: color-mix(in srgb, #d97706 18%, var(--cfpt-surface));
   color: var(--cfpt-text);
@@ -105,20 +146,20 @@ button, textarea, input { font: inherit; }
   margin-bottom: 10px;
 }
 .cfpt-note { color: var(--cfpt-muted); font-size: 12px; margin: 8px 0; }
-.cfpt-field { margin-bottom: 10px; }
+.cfpt-field { margin-bottom: 11px; }
 .cfpt-field label { display: block; font-size: 12px; color: var(--cfpt-muted); margin-bottom: 4px; }
 textarea, input[type="text"] {
   width: 100%;
-  background: color-mix(in srgb, var(--cfpt-surface) 92%, CanvasText 8%);
+  background: color-mix(in srgb, var(--cfpt-surface) 90%, CanvasText 10%);
   color: var(--cfpt-text);
   border: 1px solid var(--cfpt-border);
-  border-radius: 10px;
-  padding: 8px 10px;
+  border-radius: 12px;
+  padding: 10px 12px;
   font-size: 13px;
   resize: vertical;
 }
-textarea:focus, input:focus { outline: 2px solid var(--cfpt-accent); outline-offset: 1px; }
-.cfpt-radio-row { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 8px; font-size: 13px; }
+textarea:focus, input:focus, select:focus { outline: 2px solid var(--cfpt-accent); outline-offset: 1px; }
+.cfpt-radio-row { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 9px; font-size: 13px; }
 .cfpt-radio-row label { display: flex; align-items: center; gap: 5px; cursor: pointer; }
 .cfpt-btn {
   display: inline-flex;
@@ -157,13 +198,13 @@ textarea:focus, input:focus { outline: 2px solid var(--cfpt-accent); outline-off
 @keyframes cfpt-spin { to { transform: rotate(360deg); } }
 .cfpt-counters { color: var(--cfpt-muted); font-size: 12px; margin-bottom: 8px; }
 .cfpt-log {
-  background: color-mix(in srgb, var(--cfpt-surface) 90%, #000 10%);
+  background: color-mix(in srgb, var(--cfpt-surface) 88%, #000 12%);
   border: 1px solid var(--cfpt-border);
   border-radius: 10px;
   padding: 8px;
   font-size: 11px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  max-height: 150px;
+  max-height: 170px;
   overflow-y: auto;
   white-space: pre-wrap;
   word-break: break-word;
@@ -174,34 +215,23 @@ textarea:focus, input:focus { outline: 2px solid var(--cfpt-accent); outline-off
 .cfpt-link { color: #3b82f6; text-decoration: none; }
 .cfpt-link:hover { text-decoration: underline; }
 .cfpt-onboarding-toast {
+  position: fixed;
   pointer-events: auto;
-  position: absolute;
-  inset-inline-end: -4px;
-  bottom: 48px;
-  width: min(300px, calc(100vw - 24px));
-  padding: 13px;
-  padding-top: 15px;
+  width: min(310px, calc(100vw - 24px));
+  padding: 14px;
+  padding-top: 16px;
   border: 1px solid var(--cfpt-border);
-  border-radius: 14px;
-  background: var(--cfpt-surface);
+  border-radius: 15px;
+  background: color-mix(in srgb, var(--cfpt-surface) 94%, transparent);
   color: var(--cfpt-text);
-  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 14px 42px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
   font-size: 12px;
   line-height: 1.4;
 }
 .cfpt-onboarding-toast strong { display: block; padding-right: 22px; font-size: 13px; }
 .cfpt-onboarding-toast p { margin: 6px 0 10px; color: var(--cfpt-muted); }
-.cfpt-toast-arrow {
-  position: absolute;
-  inset-inline-end: 15px;
-  bottom: -6px;
-  width: 11px;
-  height: 11px;
-  background: var(--cfpt-surface);
-  border-right: 1px solid var(--cfpt-border);
-  border-bottom: 1px solid var(--cfpt-border);
-  transform: rotate(45deg);
-}
 .cfpt-icon-close {
   position: absolute;
   top: 7px;
@@ -217,17 +247,10 @@ textarea:focus, input:focus { outline: 2px solid var(--cfpt-accent); outline-off
   line-height: 1;
 }
 .cfpt-icon-close:hover { background: var(--cfpt-hover); color: var(--cfpt-text); }
-.cfpt-check-row {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  color: var(--cfpt-muted);
-  cursor: pointer;
-}
+.cfpt-check-row { display: flex; align-items: center; gap: 7px; color: var(--cfpt-muted); cursor: pointer; }
 .cfpt-check-row input { margin: 0; }
 .cfpt-toast-continue { margin-top: 10px; margin-right: 0; }
 .cfpt-setup-backdrop {
-  pointer-events: auto;
   position: fixed;
   inset: 0;
   width: 100vw;
@@ -235,30 +258,30 @@ textarea:focus, input:focus { outline: 2px solid var(--cfpt-accent); outline-off
   display: grid;
   place-items: center;
   padding: 18px;
+  pointer-events: auto;
   background: rgba(0, 0, 0, 0.18);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
-  z-index: 2147483600;
 }
 .cfpt-setup-card {
   position: relative;
-  width: min(440px, calc(100vw - 28px));
-  max-height: min(78vh, 620px);
+  width: min(510px, calc(100vw - 28px));
+  max-height: min(82vh, 680px);
   overflow-y: auto;
-  padding: 20px;
+  padding: 21px;
   border: 1px solid var(--cfpt-border);
-  border-radius: 18px;
-  background: var(--cfpt-surface);
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--cfpt-surface) 94%, transparent);
   color: var(--cfpt-text);
   box-shadow: 0 24px 72px rgba(0, 0, 0, 0.28);
 }
 .cfpt-setup-icon {
-  width: 34px;
-  height: 34px;
+  width: 36px;
+  height: 36px;
   display: grid;
   place-items: center;
   margin-bottom: 10px;
-  border-radius: 10px;
+  border-radius: 11px;
   background: color-mix(in srgb, var(--cfpt-accent) 14%, var(--cfpt-surface));
   color: var(--cfpt-accent);
 }
@@ -276,14 +299,26 @@ textarea:focus, input:focus { outline: 2px solid var(--cfpt-accent); outline-off
   overflow-wrap: anywhere;
 }
 .cfpt-setup-footnote { margin: 12px 0 0; color: var(--cfpt-muted); font-size: 11px; line-height: 1.45; }
-.cfpt-setup-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+.cfpt-setup-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; margin-top: 14px; }
 .cfpt-setup-actions .cfpt-btn { margin: 0; }
-@media (max-width: 520px) {
-  :host { inset-inline-end: 48px; bottom: 7px; }
-  .cfpt-panel { width: min(350px, calc(100vw - 16px)); bottom: 42px; }
-  .cfpt-body { padding: 12px; }
+.cfpt-plan-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 10px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cfpt-accent) 13%, transparent);
+  color: var(--cfpt-text);
+  font-size: 11px;
+  font-weight: 700;
+}
+@media (max-width: 620px) {
+  :host([data-cfpt-host="launcher"]) { width: 34px; height: 34px; }
+  .cfpt-launcher { width: 34px; height: 34px; }
+  .cfpt-panel { min-height: min(330px, 62vh); border-radius: 22px; }
+  .cfpt-body { padding: 13px 14px 15px; }
   .cfpt-btn { padding-inline: 11px; }
-  .cfpt-onboarding-toast { width: min(286px, calc(100vw - 16px)); }
   .cfpt-setup-card { padding: 17px; }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/tests/panel.test.ts
+++ b/tests/panel.test.ts
@@ -135,6 +135,7 @@ describe("native composer launcher placement", () => {
     expect(PANEL_CSS).toContain(".cfpt-takeover-backdrop");
     expect(PANEL_CSS).toContain("backdrop-filter: blur(22px)");
     expect(PANEL_CSS).toContain('data-cfpt-host="launcher"');
+    expect(PANEL_CSS).toContain("z-index: 2147483646");
     expect(PANEL_CSS).not.toContain(".cfpt-dock");
   });
 });

--- a/tests/panel.test.ts
+++ b/tests/panel.test.ts
@@ -5,7 +5,9 @@ import { PANEL_CSS } from "../src/content/ui/styles";
 import { installChromeMock } from "./chrome-mock";
 
 const panels: Panel[] = [];
+const shadows: ShadowRoot[] = [];
 let stores: ReturnType<typeof installChromeMock>;
+let attachShadowSpy: ReturnType<typeof vi.spyOn>;
 
 function fixture(): void {
   document.body.innerHTML = `
@@ -14,14 +16,16 @@ function fixture(): void {
         <div id="thread-bottom">
           <div data-prompt-textarea-header></div>
           <form data-type="unified-composer">
-            <div data-composer-surface="true">
+            <div data-composer-surface="true" aria-hidden="false" style="pointer-events: auto">
+              <div class="left-controls">
+                <button data-testid="composer-plus-btn" aria-label="Add files">+</button>
+              </div>
               <div id="prompt-textarea" class="ProseMirror" contenteditable="true"></div>
             </div>
           </form>
         </div>
       </div>
-    </main>
-  `;
+    </main>`;
 }
 
 function makePanel(): Panel {
@@ -36,8 +40,33 @@ function makePanel(): Panel {
 
 function host(): HTMLElement {
   const element = document.getElementById("cfpt-root");
-  if (!element) throw new Error("embedded Chat FreePT host missing");
+  if (!element) throw new Error("Chat FreePT launcher host missing");
   return element;
+}
+
+function overlayHost(): HTMLElement {
+  const element = document.getElementById("cfpt-overlay-root");
+  if (!element) throw new Error("Chat FreePT overlay host missing");
+  return element;
+}
+
+function overlayShadow(): ShadowRoot {
+  const root = shadows.at(-1);
+  if (!root) throw new Error("Chat FreePT overlay shadow missing");
+  return root;
+}
+
+function nativeSurface(): HTMLElement {
+  const surface = document.querySelector<HTMLElement>('[data-composer-surface="true"]');
+  if (!surface) throw new Error("native composer surface missing");
+  return surface;
+}
+
+function onboardingDone(): void {
+  stores.local["cfpt:onboarding:v1"] = {
+    launcherTipSuppressed: true,
+    setupShown: true,
+  };
 }
 
 async function settle(): Promise<void> {
@@ -47,68 +76,169 @@ async function settle(): Promise<void> {
 beforeEach(() => {
   stores = installChromeMock();
   fixture();
+  shadows.splice(0);
+  const original = HTMLElement.prototype.attachShadow;
+  attachShadowSpy = vi.spyOn(HTMLElement.prototype, "attachShadow").mockImplementation(function (
+    this: HTMLElement,
+    init: ShadowRootInit,
+  ) {
+    const root = original.call(this, init);
+    shadows.push(root);
+    return root;
+  });
 });
 
 afterEach(() => {
   panels.splice(0).forEach((panel) => panel.dispose());
+  attachShadowSpy.mockRestore();
+  shadows.splice(0);
 });
 
-describe("composer airplane launcher", () => {
-  it("mounts exactly once inside the ChatGPT composer surface", () => {
+describe("native composer launcher placement", () => {
+  it("mounts immediately to the right of ChatGPT's + button", () => {
+    onboardingDone();
     makePanel();
-    const surface = document.querySelector('[data-composer-surface="true"]');
-    const header = document.querySelector("[data-prompt-textarea-header]");
+    const plus = document.querySelector('[data-testid="composer-plus-btn"]');
 
-    expect(surface?.querySelector("#cfpt-root")).toBe(host());
-    expect(header?.querySelector("#cfpt-root")).toBeNull();
+    expect(plus?.nextElementSibling).toBe(host());
+    expect(host().parentElement).toBe(plus?.parentElement);
+    expect(host().dataset["fallback"]).toBe("false");
     expect(document.querySelectorAll("#cfpt-root")).toHaveLength(1);
-    expect(host().dataset["cfptEmbedded"]).toBe("true");
+  });
+
+  it("keeps the expanded surface outside the native composer DOM", () => {
+    onboardingDone();
+    makePanel();
+
+    expect(overlayHost().parentElement).toBe(document.body);
+    expect(nativeSurface().contains(overlayHost())).toBe(false);
     expect(host().dataset["cfptLauncher"]).toBe("airplane");
   });
 
-  it("uses a compact launcher instead of the old full-width dock", () => {
-    expect(PANEL_CSS).toContain(".cfpt-launcher");
-    expect(PANEL_CSS).toContain(".cfpt-airplane");
-    expect(PANEL_CSS).not.toContain(".cfpt-dock");
-  });
-
-  it("tracks toggle and rendered status on the light-DOM host", () => {
-    const panel = makePanel();
-    const idle = newRunState("conversation-1", 1);
-
-    panel.render(idle);
-    expect(host().dataset["status"]).toBe("idle");
-    expect(host().dataset["phase"]).toBe("idle");
-    expect(host().dataset["expanded"]).toBe("false");
-
-    panel.toggle();
-    expect(host().dataset["expanded"]).toBe("true");
-
-    panel.render({
-      ...idle,
-      phase: "planning",
-      status: "awaiting_user",
-      pauseReason: "Choose a repository name",
-    });
-    expect(host().dataset["state"]).toBe("attention");
-    expect(host().dataset["status"]).toBe("awaiting_user");
-  });
-
-  it("re-homes the same host when ChatGPT replaces the composer surface", async () => {
+  it("re-homes the same launcher beside a replacement + button", async () => {
+    onboardingDone();
     makePanel();
-    const first = document.querySelector('[data-composer-surface="true"]');
     const replacement = document.createElement("div");
     replacement.setAttribute("data-composer-surface", "true");
-    replacement.innerHTML = '<div id="prompt-textarea" contenteditable="true"></div>';
-    first?.replaceWith(replacement);
-
+    replacement.innerHTML = `
+      <div class="left-controls"><button data-testid="composer-plus-btn" aria-label="Add files">+</button></div>
+      <div id="prompt-textarea" contenteditable="true"></div>`;
+    nativeSurface().replaceWith(replacement);
     await settle();
 
-    expect(replacement.querySelector("#cfpt-root")).toBe(host());
+    const plus = replacement.querySelector('[data-testid="composer-plus-btn"]');
+    expect(plus?.nextElementSibling).toBe(host());
     expect(document.querySelectorAll("#cfpt-root")).toHaveLength(1);
   });
 
-  it("expands the composer controls for completion instead of creating a completion overlay", () => {
+  it("uses integrated takeover styles rather than the old detached dock", () => {
+    expect(PANEL_CSS).toContain(".cfpt-takeover-backdrop");
+    expect(PANEL_CSS).toContain("backdrop-filter: blur(22px)");
+    expect(PANEL_CSS).toContain('data-cfpt-host="launcher"');
+    expect(PANEL_CSS).not.toContain(".cfpt-dock");
+  });
+});
+
+describe("composer takeover lifecycle", () => {
+  it("blocks the native composer while open and restores its exact state on close", () => {
+    onboardingDone();
+    const panel = makePanel();
+    panel.render(newRunState("conversation-1", 1));
+
+    panel.toggle(true);
+    expect(nativeSurface().style.pointerEvents).toBe("none");
+    expect(nativeSurface().getAttribute("aria-hidden")).toBe("true");
+    expect(nativeSurface().dataset["cfptTakeover"]).toBe("true");
+    expect(host().dataset["expanded"]).toBe("true");
+
+    panel.toggle(false);
+    expect(nativeSurface().style.pointerEvents).toBe("auto");
+    expect(nativeSurface().getAttribute("aria-hidden")).toBe("false");
+    expect(nativeSurface().dataset["cfptTakeover"]).toBeUndefined();
+  });
+
+  it("closes when the user clicks outside the integrated panel", () => {
+    onboardingDone();
+    const panel = makePanel();
+    panel.render(newRunState("conversation-1", 1));
+    panel.toggle(true);
+
+    overlayShadow().querySelector<HTMLElement>(".cfpt-takeover-backdrop")?.click();
+    expect(host().dataset["expanded"]).toBe("false");
+    expect(nativeSurface().style.pointerEvents).toBe("auto");
+  });
+
+  it("closes on Escape", () => {
+    onboardingDone();
+    const panel = makePanel();
+    panel.render(newRunState("conversation-1", 1));
+    panel.toggle(true);
+
+    const body = overlayShadow().querySelector<HTMLElement>(".cfpt-body");
+    body?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(host().dataset["expanded"]).toBe("false");
+  });
+
+  it("keeps planning input focus outside ChatGPT's composer focus handlers", () => {
+    onboardingDone();
+    const nativeFocus = vi.fn();
+    nativeSurface().addEventListener("focusin", nativeFocus);
+    const panel = makePanel();
+    panel.render(newRunState("conversation-1", 1));
+    panel.toggle(true);
+
+    const idea = overlayShadow().querySelector<HTMLTextAreaElement>('[data-ref="idea"]');
+    idea?.focus();
+    expect(overlayShadow().activeElement).toBe(idea);
+    expect(nativeFocus).not.toHaveBeenCalled();
+  });
+});
+
+describe("first-run and plan-aware setup", () => {
+  it("keeps the working launcher-tip then setup sequence", async () => {
+    const panel = makePanel();
+    await settle();
+    expect(host().dataset["onboarding"]).toBe("tip");
+    expect(host().dataset["highlighted"]).toBe("true");
+
+    await panel.acknowledgeLauncherTip(true);
+    expect(host().dataset["onboarding"]).toBe("setup");
+    expect(host().dataset["highlighted"]).toBe("false");
+
+    await panel.acknowledgeSetup();
+    expect(host().dataset["onboarding"]).toBe("done");
+    expect(stores.local["cfpt:onboarding:v1"]).toEqual({
+      launcherTipSuppressed: true,
+      setupShown: true,
+    });
+  });
+
+  it("offers an opt-in follow-along path and a separate Free path", async () => {
+    onboardingDone();
+    const panel = makePanel();
+    panel.render(newRunState("conversation-1", 1));
+    panel.toggle(true);
+    overlayShadow().querySelector<HTMLButtonElement>('[data-action="setup-open"]')?.click();
+
+    expect(overlayShadow().textContent).toContain("Follow along");
+    expect(overlayShadow().textContent).toContain("Using ChatGPT Free?");
+    overlayShadow().querySelector<HTMLButtonElement>('[data-action="free-setup"]')?.click();
+    expect(overlayShadow().textContent).toContain("Prepare GitHub manually first");
+    expect(overlayShadow().textContent).toContain("Existing repo");
+    expect(overlayShadow().textContent).toContain("NEEDS_INPUT");
+  });
+
+  it("does not re-show onboarding after suppression and completion", async () => {
+    onboardingDone();
+    makePanel();
+    await settle();
+
+    expect(host().dataset["onboarding"]).toBe("done");
+    expect(host().dataset["highlighted"]).toBe("false");
+  });
+
+  it("expands the same composer takeover for completion", () => {
+    onboardingDone();
     const panel = makePanel();
     const complete = {
       ...newRunState("conversation-1", 1),
@@ -120,81 +250,6 @@ describe("composer airplane launcher", () => {
     panel.showCompletionModal(complete);
 
     expect(host().dataset["expanded"]).toBe("true");
-    expect(document.querySelector(".cfpt-modal-backdrop")).toBeNull();
-  });
-});
-
-describe("first-run onboarding", () => {
-  it("uses a dedicated blurred setup backdrop", () => {
-    expect(PANEL_CSS).toContain(".cfpt-setup-backdrop");
-    expect(PANEL_CSS).toContain("backdrop-filter: blur(4px)");
-  });
-
-  it("shows the launcher tip first, highlights the airplane, then shows setup", async () => {
-    const panel = makePanel();
-    await settle();
-
-    expect(host().dataset["onboarding"]).toBe("tip");
-    expect(host().dataset["highlighted"]).toBe("true");
-
-    await panel.acknowledgeLauncherTip(true);
-    expect(host().dataset["onboarding"]).toBe("setup");
-    expect(host().dataset["highlighted"]).toBe("false");
-    expect(stores.local["cfpt:onboarding:v1"]).toEqual({
-      launcherTipSuppressed: true,
-      setupShown: false,
-    });
-
-    await panel.acknowledgeSetup();
-    expect(host().dataset["onboarding"]).toBe("done");
-    expect(stores.local["cfpt:onboarding:v1"]).toEqual({
-      launcherTipSuppressed: true,
-      setupShown: true,
-    });
-  });
-
-  it("does not show either onboarding surface again after suppression and setup completion", async () => {
-    stores.local["cfpt:onboarding:v1"] = {
-      launcherTipSuppressed: true,
-      setupShown: true,
-    };
-
-    makePanel();
-    await settle();
-
-    expect(host().dataset["onboarding"]).toBe("done");
-    expect(host().dataset["highlighted"]).toBe("false");
-  });
-
-  it("shows the launcher tip again when the user did not check don't-show-again", async () => {
-    const panel = makePanel();
-    await settle();
-    await panel.acknowledgeLauncherTip(false);
-    await panel.acknowledgeSetup();
-    panel.dispose();
-
-    fixture();
-    makePanel();
-    await settle();
-
-    expect(stores.local["cfpt:onboarding:v1"]).toEqual({
-      launcherTipSuppressed: false,
-      setupShown: true,
-    });
-    expect(host().dataset["onboarding"]).toBe("tip");
-    expect(host().dataset["highlighted"]).toBe("true");
-  });
-
-  it("goes directly to the one-time setup dialog when only the launcher tip is suppressed", async () => {
-    stores.local["cfpt:onboarding:v1"] = {
-      launcherTipSuppressed: true,
-      setupShown: false,
-    };
-
-    makePanel();
-    await settle();
-
-    expect(host().dataset["onboarding"]).toBe("setup");
-    expect(host().dataset["highlighted"]).toBe("false");
+    expect(nativeSurface().dataset["cfptTakeover"]).toBe("true");
   });
 });

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { healthCheck, query, queryAll, queryLast, resolve } from "../src/content/selectors";
+import {
+  healthCheck,
+  query,
+  queryAll,
+  queryGuideTarget,
+  queryLast,
+  resolve,
+} from "../src/content/selectors";
 
-/**
- * Synthetic fixture shaped from the current chatgpt.com DOM capture: the thread owns
- * section turns, the composer is unified, and Chat FreePT mounts in the composer surface.
- */
 const CHATGPT_FIXTURE = `
   <main id="main">
     <div id="thread">
@@ -18,9 +21,7 @@ const CHATGPT_FIXTURE = `
       <div data-turn-id-container="request-assistant-1">
         <section data-testid="conversation-turn-2" data-turn="assistant">
           <div class="agent-turn">
-            <div data-message-author-role="assistant" data-message-id="a1">
-              <div class="markdown">working on it</div>
-            </div>
+            <div data-message-author-role="assistant" data-message-id="a1">working on it</div>
           </div>
         </section>
       </div>
@@ -28,7 +29,7 @@ const CHATGPT_FIXTURE = `
         <section data-testid="conversation-turn-3" data-turn="assistant">
           <div class="agent-turn">
             <div data-message-author-role="assistant" data-message-id="a2">
-              <div class="markdown">done<pre><code>CHATFREEPT_STATUS: CONTINUE</code></pre></div>
+              done<pre><code>CHATFREEPT_STATUS: CONTINUE</code></pre>
             </div>
           </div>
         </section>
@@ -37,6 +38,9 @@ const CHATGPT_FIXTURE = `
         <div data-prompt-textarea-header></div>
         <form data-type="unified-composer">
           <div data-composer-surface="true">
+            <div class="left-controls">
+              <button data-testid="composer-plus-btn" aria-label="Add files">+</button>
+            </div>
             <div id="prompt-textarea" class="ProseMirror" contenteditable="true"><p></p></div>
             <button data-testid="send-button" aria-label="Send prompt"></button>
           </div>
@@ -50,8 +54,8 @@ beforeEach(() => {
   document.body.innerHTML = CHATGPT_FIXTURE;
 });
 
-describe("selector registry", () => {
-  it("resolves primary candidates on the captured ChatGPT structure", () => {
+describe("core selector resolution", () => {
+  it("resolves primary candidates on the current composer structure", () => {
     expect(resolve("composer")?.candidateIndex).toBe(0);
     expect(resolve("composerHeader")?.candidateIndex).toBe(0);
     expect(resolve("composerSurface")?.candidateIndex).toBe(0);
@@ -61,12 +65,11 @@ describe("selector registry", () => {
     expect(resolve("userMessage")?.candidateIndex).toBe(0);
   });
 
-  it("queryLast returns the newest assistant message", () => {
-    const el = queryLast("assistantMessage");
-    expect(el?.getAttribute("data-message-id")).toBe("a2");
+  it("returns the newest assistant message", () => {
+    expect(queryLast("assistantMessage")?.getAttribute("data-message-id")).toBe("a2");
   });
 
-  it("queryAll returns all alert and toast matches", () => {
+  it("returns all alert and toast matches", () => {
     document.body.insertAdjacentHTML(
       "beforeend",
       '<div role="alert">one</div><div class="toast-banner">two</div>',
@@ -80,22 +83,23 @@ describe("selector registry", () => {
     expect(query("toolIndicator", turn)?.textContent).toBe("GitHub");
   });
 
-  it("does not treat an empty-composer Send button absence as unhealthy", () => {
+  it("treats an empty-composer Send button absence as healthy", () => {
     document.querySelector('[data-testid="send-button"]')?.remove();
     expect(query("sendButton")).toBeNull();
     expect(healthCheck().missing).toEqual([]);
   });
+});
 
-  it("falls back down the composer, header, and surface candidate lists", () => {
+describe("selector fallbacks and health", () => {
+  it("falls back down the composer, header, and surface candidates", () => {
     document.getElementById("prompt-textarea")?.removeAttribute("id");
     document.getElementById("thread-bottom")?.removeAttribute("id");
-
     expect(resolve("composer")?.candidateIndex).toBeGreaterThan(0);
     expect(resolve("composerHeader")?.candidateIndex).toBeGreaterThan(0);
     expect(resolve("composerSurface")?.candidateIndex).toBeGreaterThan(0);
   });
 
-  it("falls back to the unified form when the composer-surface attribute disappears", () => {
+  it("falls back to the unified form when the surface attribute disappears", () => {
     document
       .querySelector('[data-composer-surface="true"]')
       ?.removeAttribute("data-composer-surface");
@@ -106,10 +110,10 @@ describe("selector registry", () => {
 
   it("filters text-matched Send candidates", () => {
     document.querySelector('[data-testid="send-button"]')?.remove();
-    const form = document.querySelector("form");
-    form?.insertAdjacentHTML("beforeend", "<button>Cancel</button><button>Send</button>");
-    const res = resolve("sendButton");
-    expect(res?.element.textContent).toBe("Send");
+    document
+      .querySelector("form")
+      ?.insertAdjacentHTML("beforeend", "<button>Cancel</button><button>Send</button>");
+    expect(resolve("sendButton")?.element.textContent).toBe("Send");
   });
 
   it("reports stop button absence as no streaming", () => {
@@ -120,9 +124,7 @@ describe("selector registry", () => {
     expect(query("stopButton")).not.toBeNull();
   });
 
-  it("healthCheck fails only when an automation-required target vanishes", () => {
-    expect(healthCheck().missing).toEqual([]);
-
+  it("fails health only when an automation-required target vanishes", () => {
     document.getElementById("prompt-textarea")?.remove();
     document.querySelectorAll('[contenteditable="true"]').forEach((el) => el.remove());
     const report = healthCheck();
@@ -132,9 +134,54 @@ describe("selector registry", () => {
     expect(report.missing).not.toContain("composerSurface");
   });
 
-  it("healthCheck reports degradation when the primary composer drifts", () => {
+  it("reports degradation when the primary composer drifts", () => {
     document.getElementById("prompt-textarea")?.removeAttribute("id");
-    const report = healthCheck();
-    expect(report.degraded.some((item) => item.id === "composer")).toBe(true);
+    expect(healthCheck().degraded.some((item) => item.id === "composer")).toBe(true);
+  });
+});
+
+describe("composer and guided-setup targets", () => {
+  it("resolves the native composer + button", () => {
+    expect(queryGuideTarget("composerPlusButton")?.dataset["testid"]).toBe("composer-plus-btn");
+  });
+
+  it("resolves Security and login, Developer mode row, and its switch", () => {
+    document.body.innerHTML = `
+      <nav><button>Security and login</button></nav>
+      <section class="developer-row">
+        <div><strong>Developer mode</strong><span>Elevated Risk</span></div>
+        <button role="switch" aria-checked="false" aria-label="Developer mode"></button>
+      </section>`;
+
+    expect(queryGuideTarget("settingsSecurity")?.textContent).toContain("Security and login");
+    expect(queryGuideTarget("developerModeRow")?.classList.contains("developer-row")).toBe(true);
+    expect(queryGuideTarget("developerModeToggle")?.getAttribute("role")).toBe("switch");
+  });
+
+  it("resolves every field in the New Plugin form", () => {
+    document.body.innerHTML = `
+      <button aria-label="Add plugin">+</button>
+      <label for="plugin-name">Name</label><input id="plugin-name" />
+      <label for="server-url">Server URL</label><input id="server-url" type="url" />
+      <label for="auth">Authentication</label><select id="auth"><option>OAuth</option></select>
+      <label><span>I understand the risks and want to continue</span><input id="risk" type="checkbox" /></label>
+      <button>Create</button>`;
+
+    expect(queryGuideTarget("pluginAddButton")?.getAttribute("aria-label")).toBe("Add plugin");
+    expect(queryGuideTarget("pluginNameInput")?.id).toBe("plugin-name");
+    expect(queryGuideTarget("pluginServerInput")?.id).toBe("server-url");
+    expect(queryGuideTarget("pluginAuthControl")?.id).toBe("auth");
+    expect(queryGuideTarget("pluginRiskCheckbox")?.id).toBe("risk");
+    expect(queryGuideTarget("pluginCreateButton")?.textContent).toBe("Create");
+  });
+
+  it("resolves Developer mode and GitHub MCP choices in the conversation menu", () => {
+    document.body.innerHTML = `
+      <div role="menu">
+        <button role="menuitem">Developer mode</button>
+        <button role="menuitem">GitHub MCP</button>
+      </div>`;
+    expect(queryGuideTarget("conversationDeveloperMode")?.textContent).toBe("Developer mode");
+    expect(queryGuideTarget("conversationGitHubMcp")?.textContent).toBe("GitHub MCP");
   });
 });

--- a/tests/setup-guide.test.ts
+++ b/tests/setup-guide.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SetupGuide } from "../src/content/ui/setup-guide";
+import { installChromeMock } from "./chrome-mock";
+
+let stores: ReturnType<typeof installChromeMock>;
+let shadow: ShadowRoot;
+let attachShadowSpy: ReturnType<typeof vi.spyOn>;
+let guide: SetupGuide | undefined;
+
+function stored(step: string): void {
+  stores.local["cfpt:setup-guide:v1"] = {
+    active: true,
+    step,
+    returnUrl: "https://chatgpt.com/c/example",
+  };
+}
+
+function makeGuide(): SetupGuide {
+  guide = new SetupGuide();
+  return guide;
+}
+
+async function settle(ms = 0): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+beforeEach(() => {
+  stores = installChromeMock();
+  document.body.innerHTML = "";
+  const original = HTMLElement.prototype.attachShadow;
+  attachShadowSpy = vi.spyOn(HTMLElement.prototype, "attachShadow").mockImplementation(function (
+    this: HTMLElement,
+    init: ShadowRootInit,
+  ) {
+    shadow = original.call(this, init);
+    return shadow;
+  });
+});
+
+afterEach(() => {
+  guide?.dispose();
+  guide = undefined;
+  attachShadowSpy.mockRestore();
+});
+
+describe("opt-in setup guide", () => {
+  it("highlights only Security and login, then clears it for the next step", async () => {
+    stored("security");
+    document.body.innerHTML = '<button id="security">Security and login</button>';
+    makeGuide();
+    await settle();
+
+    const ring = shadow.querySelector(".cfpt-guide-ring");
+    expect(shadow.querySelectorAll(".cfpt-guide-ring")).toHaveLength(1);
+    expect(ring?.classList.contains("cfpt-guide-hidden")).toBe(false);
+    expect(shadow.textContent).toContain("1 · Security and login");
+
+    document.getElementById("security")?.click();
+    await settle(100);
+    expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ step: "developer" });
+    expect(ring?.classList.contains("cfpt-guide-hidden")).toBe(true);
+  });
+
+  it("advances only after the Developer mode switch becomes enabled", async () => {
+    stored("developer-toggle");
+    document.body.innerHTML = `
+      <section>
+        <span>Developer mode</span>
+        <button id="developer-switch" role="switch" aria-checked="false"></button>
+      </section>`;
+    const toggle = document.getElementById("developer-switch");
+    toggle?.addEventListener("click", () => toggle.setAttribute("aria-checked", "true"));
+    makeGuide();
+    await settle();
+
+    expect(shadow.textContent).toContain("3 · Enable Developer mode");
+    toggle?.click();
+    await settle(150);
+    expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ step: "plugins" });
+  });
+
+  it("fills the exact GitHub MCP server URL using native input events", async () => {
+    stored("plugin-server");
+    document.body.innerHTML = `
+      <label for="server-url">Server URL</label>
+      <input id="server-url" type="url" />`;
+    const input = document.getElementById("server-url") as HTMLInputElement;
+    const inputEvent = vi.fn();
+    const changeEvent = vi.fn();
+    input.addEventListener("input", inputEvent);
+    input.addEventListener("change", changeEvent);
+    makeGuide();
+    await settle();
+
+    shadow.querySelector<HTMLButtonElement>('[data-guide-action="fill-url"]')?.click();
+    await settle();
+    expect(input.value).toBe("https://api.githubcopilot.com/mcp/");
+    expect(inputEvent).toHaveBeenCalledTimes(1);
+    expect(changeEvent).toHaveBeenCalledTimes(1);
+    expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ step: "plugin-auth" });
+  });
+
+  it("removes the current highlight and persistence when cancelled", async () => {
+    stored("security");
+    document.body.innerHTML = '<button id="security">Security and login</button>';
+    makeGuide();
+    await settle();
+
+    shadow.querySelector<HTMLButtonElement>('[data-guide-action="cancel"]')?.click();
+    await settle();
+    expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ active: false });
+    expect(shadow.querySelector(".cfpt-guide-ring")?.classList.contains("cfpt-guide-hidden")).toBe(
+      true,
+    );
+    expect(shadow.querySelector(".cfpt-guide-card")?.classList.contains("cfpt-guide-hidden")).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Refs #50

## Result
Make Chat FreePT feel native to the current ChatGPT composer: airplane beside the native `+`, full-width translucent composer takeover, stable extension input focus, outside-click close, and an opt-in highlighted setup walkthrough.

## Implementation
Moves expanded controls out of ChatGPT's composer DOM, adds centralized composer/setup target resolution, introduces a persisted step-by-step Developer mode → Plugins → GitHub MCP guide, and adds a Free/manual setup path while preserving existing automation semantics.

## Verification
Add focused selector, panel/takeover, focus, onboarding, free-path, and setup-guide tests; then run the repository's full hosted PR gates and resolve failures by root cause.

## Risk
Host-DOM/UI integration change. No new runtime dependencies, extension permissions, private ChatGPT APIs, network interception, CI thresholds, or release-policy changes.

## Remaining work
Finish regression coverage, verify all hosted checks, preserve the exact CI-built installable artifact, and require another live browser validation pass before any `dev → main` release.