### PR TITLE
Stop stale content scripts after extension reload

### DIFF
--- a/src/content/extension-context.ts
+++ b/src/content/extension-context.ts
@@ -1,0 +1,34 @@
+const INVALIDATED_CONTEXT_RE = /extension context invalidated/i;
+
+export function isExtensionContextInvalidated(error: unknown): boolean {
+  if (error instanceof Error) return INVALIDATED_CONTEXT_RE.test(error.message);
+  return typeof error === "string" && INVALIDATED_CONTEXT_RE.test(error);
+}
+
+export interface ExtensionContextGuard {
+  readonly invalidated: boolean;
+  handle(error: unknown): boolean;
+}
+
+/**
+ * Chrome leaves already-injected content scripts alive when an extension is reloaded or
+ * disabled, but their chrome.* context is dead. Treat that state as terminal and dispose
+ * the stale instance exactly once instead of retrying extension APIs forever.
+ */
+export function createExtensionContextGuard(onInvalidated: () => void): ExtensionContextGuard {
+  let invalidated = false;
+
+  return {
+    get invalidated(): boolean {
+      return invalidated;
+    },
+    handle(error: unknown): boolean {
+      if (!isExtensionContextInvalidated(error)) return false;
+      if (!invalidated) {
+        invalidated = true;
+        onInvalidated();
+      }
+      return true;
+    },
+  };
+}

--- a/src/content/extension-context.ts
+++ b/src/content/extension-context.ts
@@ -7,6 +7,7 @@ export function isExtensionContextInvalidated(error: unknown): boolean {
 
 export interface ExtensionContextGuard {
   readonly invalidated: boolean;
+  invalidate(): void;
   handle(error: unknown): boolean;
 }
 
@@ -17,17 +18,20 @@ export interface ExtensionContextGuard {
  */
 export function createExtensionContextGuard(onInvalidated: () => void): ExtensionContextGuard {
   let invalidated = false;
+  const invalidate = (): void => {
+    if (invalidated) return;
+    invalidated = true;
+    onInvalidated();
+  };
 
   return {
     get invalidated(): boolean {
       return invalidated;
     },
+    invalidate,
     handle(error: unknown): boolean {
       if (!isExtensionContextInvalidated(error)) return false;
-      if (!invalidated) {
-        invalidated = true;
-        onInvalidated();
-      }
+      invalidate();
       return true;
     },
   };

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -11,6 +11,7 @@ import {
 } from "../common/storage";
 import type { RunState, Settings } from "../common/types";
 import type { ContentRequest } from "../common/types";
+import { createExtensionContextGuard } from "./extension-context";
 import { conversationIdFromUrl, watchNavigation } from "./navigation";
 import { RunController } from "./run-controller";
 import { require_ } from "./selectors";
@@ -25,6 +26,9 @@ let controller: RunController | null = null;
 let currentConvId = "";
 let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 let takeoverTimer: ReturnType<typeof setTimeout> | undefined;
+let stopNavigation: (() => void) | undefined;
+
+const contextGuard = createExtensionContextGuard(() => shutdownInvalidatedContext());
 
 function conversationKeyFromLocation(): string {
   return conversationIdFromUrl(location.href) ?? `pending:${crypto.randomUUID()}`;
@@ -40,19 +44,50 @@ function stopTakeoverRetry(): void {
   takeoverTimer = undefined;
 }
 
+function shutdownInvalidatedContext(): void {
+  stopHeartbeat();
+  stopTakeoverRetry();
+  stopNavigation?.();
+  stopNavigation = undefined;
+  controller?.dispose();
+  controller = null;
+  panel?.dispose();
+  panel = null;
+}
+
+function reportAsyncFailure(message: string, error: unknown): void {
+  if (contextGuard.handle(error)) return;
+  log.warn(message, error);
+}
+
+async function releaseOwnedLock(conversationId: string): Promise<void> {
+  if (contextGuard.invalidated || !conversationId) return;
+  try {
+    await releaseTabLock(conversationId, tabNonce);
+  } catch (error) {
+    reportAsyncFailure("tab lock release failed", error);
+  }
+}
+
 function startHeartbeat(): void {
   stopHeartbeat();
+  if (contextGuard.invalidated) return;
   heartbeatTimer = setInterval(() => {
+    if (contextGuard.invalidated) {
+      stopHeartbeat();
+      return;
+    }
     const conversationId = currentConvId;
     void heartbeatTabLock(conversationId, tabNonce)
       .then((owned) => {
         if (!owned) loseOwnership(conversationId);
       })
-      .catch((error) => log.warn("tab lock heartbeat failed", error));
+      .catch((error) => reportAsyncFailure("tab lock heartbeat failed", error));
   }, HEARTBEAT_MS);
 }
 
 function startController(state: RunState, settings: Settings): void {
+  if (contextGuard.invalidated) return;
   stopTakeoverRetry();
   startHeartbeat();
   const ctl = new RunController(state, settings, {
@@ -60,6 +95,7 @@ function startController(state: RunState, settings: Settings): void {
     onShowModal: () => {
       if (controller) panel?.showCompletionModal(controller.state);
     },
+    onContextInvalidated: () => contextGuard.invalidate(),
   });
   controller = ctl;
   panel?.render(state);
@@ -67,12 +103,13 @@ function startController(state: RunState, settings: Settings): void {
   if (isActive(state)) {
     log.info("resuming active run", state.phase, state.status);
     setTimeout(() => {
-      if (controller === ctl) ctl.reconcile();
+      if (controller === ctl && !contextGuard.invalidated) ctl.reconcile();
     }, 2000);
   }
 }
 
 function enterPassive(state: RunState): void {
+  if (contextGuard.invalidated) return;
   controller?.dispose();
   controller = null;
   stopHeartbeat();
@@ -82,12 +119,13 @@ function enterPassive(state: RunState): void {
 
 function scheduleTakeover(conversationId: string): void {
   stopTakeoverRetry();
+  if (contextGuard.invalidated) return;
   takeoverTimer = setTimeout(() => void tryTakeover(conversationId), TAKEOVER_RETRY_MS);
 }
 
 async function tryTakeover(conversationId: string): Promise<void> {
   takeoverTimer = undefined;
-  if (controller || conversationId !== currentConvId) return;
+  if (contextGuard.invalidated || controller || conversationId !== currentConvId) return;
 
   let acquired = false;
   try {
@@ -98,8 +136,9 @@ async function tryTakeover(conversationId: string): Promise<void> {
     }
 
     const [settings, stored] = await Promise.all([loadSettings(), loadRun(conversationId)]);
+    if (contextGuard.invalidated) return;
     if (controller || conversationId !== currentConvId) {
-      await releaseTabLock(conversationId, tabNonce);
+      await releaseOwnedLock(conversationId);
       return;
     }
 
@@ -107,20 +146,22 @@ async function tryTakeover(conversationId: string): Promise<void> {
     startController(state, settings);
     log.info("took over conversation after previous tab became inactive");
   } catch (error) {
-    if (acquired) await releaseTabLock(conversationId, tabNonce);
+    if (contextGuard.handle(error)) return;
+    if (acquired) await releaseOwnedLock(conversationId);
     log.warn("conversation ownership retry failed", error);
     if (!controller && conversationId === currentConvId) scheduleTakeover(conversationId);
   }
 }
 
 function loseOwnership(conversationId: string): void {
-  if (!controller || conversationId !== currentConvId) return;
+  if (contextGuard.invalidated || !controller || conversationId !== currentConvId) return;
   const state = controller.state;
   log.warn("conversation ownership moved to another tab; becoming passive");
   enterPassive(state);
 }
 
 async function initConversation(convId: string): Promise<void> {
+  if (contextGuard.invalidated) return;
   controller?.dispose();
   controller = null;
   stopHeartbeat();
@@ -130,6 +171,7 @@ async function initConversation(convId: string): Promise<void> {
   const settings = await loadSettings();
   const state = (await loadRun(convId)) ?? newRunState(convId, Date.now());
   const locked = await acquireTabLock(convId, tabNonce);
+  if (contextGuard.invalidated) return;
   if (!locked) {
     log.warn("another tab is driving this conversation; staying passive");
     enterPassive(state);
@@ -140,6 +182,7 @@ async function initConversation(convId: string): Promise<void> {
 }
 
 async function onNavigate(href: string): Promise<void> {
+  if (contextGuard.invalidated) return;
   const urlConv = conversationIdFromUrl(href);
 
   if (urlConv && currentConvId.startsWith("pending:") && controller) {
@@ -151,6 +194,7 @@ async function onNavigate(href: string): Promise<void> {
     try {
       migrated = await adoptConversationOwnership(ctl.state, urlConv, tabNonce);
     } catch (error) {
+      if (contextGuard.handle(error)) return;
       log.warn("failed to adopt permanent conversation id", error);
       startHeartbeat();
       return;
@@ -159,7 +203,8 @@ async function onNavigate(href: string): Promise<void> {
     if (!migrated) {
       ctl.dispose();
       controller = null;
-      await releaseTabLock(pendingId, tabNonce);
+      await releaseOwnedLock(pendingId);
+      if (contextGuard.invalidated) return;
       currentConvId = urlConv;
       const state = (await loadRun(urlConv)) ?? newRunState(urlConv, Date.now());
       log.warn("another tab owns the permanent conversation id; staying passive");
@@ -182,7 +227,8 @@ async function onNavigate(href: string): Promise<void> {
   if (controller && isActive(controller.state)) {
     controller.dispatch({ type: "USER_PAUSE" });
   }
-  await releaseTabLock(currentConvId, tabNonce);
+  await releaseOwnedLock(currentConvId);
+  if (contextGuard.invalidated) return;
   await initConversation(urlConv ?? `pending:${crypto.randomUUID()}`);
 }
 
@@ -193,6 +239,7 @@ async function boot(): Promise<void> {
     log.warn("composer never appeared; Chat FreePT idle (logged out or layout change?)");
     return;
   }
+  if (contextGuard.invalidated) return;
 
   panel = new Panel({
     onEvent: (event) => controller?.dispatch(event),
@@ -206,12 +253,16 @@ async function boot(): Promise<void> {
   window.addEventListener("pagehide", () => {
     stopTakeoverRetry();
     stopHeartbeat();
-    void releaseTabLock(currentConvId, tabNonce);
+    stopNavigation?.();
+    stopNavigation = undefined;
+    void releaseOwnedLock(currentConvId);
   });
 
-  watchNavigation((href) => void onNavigate(href));
+  stopNavigation = watchNavigation((href) => {
+    void onNavigate(href).catch((error) => reportAsyncFailure("navigation handling failed", error));
+  });
   await initConversation(conversationKeyFromLocation());
-  log.info("Chat FreePT ready");
+  if (!contextGuard.invalidated) log.info("Chat FreePT ready");
 }
 
-void boot();
+void boot().catch((error) => reportAsyncFailure("Chat FreePT boot failed", error));

--- a/src/content/run-controller.ts
+++ b/src/content/run-controller.ts
@@ -12,6 +12,7 @@ import { cooldownRemainingMs, isActive, reduce } from "../common/state-machine";
 import { saveRun } from "../common/storage";
 import type { BgRequest, RunState, Settings } from "../common/types";
 import { clickSend, composerIsEmpty, insertPrompt } from "./composer";
+import { isExtensionContextInvalidated } from "./extension-context";
 import { scanPageSignals } from "./page-signals";
 import { healthCheck } from "./selectors";
 import { StreamWatcher } from "./stream-watch";
@@ -30,17 +31,23 @@ export class RunController {
   private lastSignal: string | null = null;
   private readonly onChange: (state: RunState) => void;
   private readonly onShowModal: () => void;
+  private readonly onContextInvalidated: () => void;
   private disposed = false;
 
   constructor(
     initial: RunState,
     settings: Settings,
-    hooks: { onChange: (state: RunState) => void; onShowModal: () => void },
+    hooks: {
+      onChange: (state: RunState) => void;
+      onShowModal: () => void;
+      onContextInvalidated?: () => void;
+    },
   ) {
     this.state = initial;
     this.settings = settings;
     this.onChange = hooks.onChange;
     this.onShowModal = hooks.onShowModal;
+    this.onContextInvalidated = hooks.onContextInvalidated ?? (() => undefined);
     this.watcher = new StreamWatcher(
       {
         onStart: () => this.dispatch({ type: "STREAM_STARTED" }),
@@ -60,12 +67,13 @@ export class RunController {
     this.watcher.stop();
     this.clearCooldownTimer();
     if (this.signalTimer !== undefined) clearInterval(this.signalTimer);
+    this.signalTimer = undefined;
   }
 
   /** A brand-new chat gets its real /c/<uuid> id after the first reply; adopt it in place. */
   adoptConversationId(conversationId: string): void {
     this.state = { ...this.state, conversationId };
-    void saveRun(this.state).catch((err) => log.warn("state save failed", err));
+    void saveRun(this.state).catch((err) => this.handleChromeFailure("state save failed", err));
   }
 
   dispatch(event: MachineEvent): void {
@@ -77,7 +85,7 @@ export class RunController {
     if (previousStatus === "cooldown" && state.status !== "cooldown") {
       this.clearCooldownTimer();
     }
-    void saveRun(state).catch((err) => log.warn("state save failed", err));
+    void saveRun(state).catch((err) => this.handleChromeFailure("state save failed", err));
     this.onChange(state);
     for (const effect of effects) void this.execute(effect);
   }
@@ -239,9 +247,19 @@ export class RunController {
   }
 
   private sendToBackground(message: BgRequest): void {
-    void chrome.runtime.sendMessage(message).catch((err) => {
-      log.debug("background message failed", err);
-    });
+    void chrome.runtime
+      .sendMessage(message)
+      .catch((err) => this.handleChromeFailure("background message failed", err, true));
+  }
+
+  private handleChromeFailure(message: string, error: unknown, debug = false): void {
+    if (isExtensionContextInvalidated(error)) {
+      this.dispose();
+      this.onContextInvalidated();
+      return;
+    }
+    if (debug) log.debug(message, error);
+    else log.warn(message, error);
   }
 }
 

--- a/tests/extension-context.test.ts
+++ b/tests/extension-context.test.ts
@@ -12,6 +12,7 @@ describe("extension context lifecycle", () => {
     expect(isExtensionContextInvalidated({ message: "Extension context invalidated." })).toBe(
       false,
     );
+    expect(isExtensionContextInvalidated(null)).toBe(false);
   });
 
   it("turns invalidation into one terminal disposal", () => {

--- a/tests/extension-context.test.ts
+++ b/tests/extension-context.test.ts
@@ -8,8 +8,12 @@ describe("extension context lifecycle", () => {
   it("recognizes Chrome extension-context invalidation errors", () => {
     expect(isExtensionContextInvalidated(new Error("Extension context invalidated."))).toBe(true);
     expect(isExtensionContextInvalidated("extension context invalidated")).toBe(true);
-    expect(isExtensionContextInvalidated(new Error("storage temporarily unavailable"))).toBe(false);
-    expect(isExtensionContextInvalidated({ message: "Extension context invalidated." })).toBe(false);
+    expect(isExtensionContextInvalidated(new Error("storage temporarily unavailable"))).toBe(
+      false,
+    );
+    expect(isExtensionContextInvalidated({ message: "Extension context invalidated." })).toBe(
+      false,
+    );
   });
 
   it("turns invalidation into one terminal disposal", () => {

--- a/tests/extension-context.test.ts
+++ b/tests/extension-context.test.ts
@@ -8,9 +8,7 @@ describe("extension context lifecycle", () => {
   it("recognizes Chrome extension-context invalidation errors", () => {
     expect(isExtensionContextInvalidated(new Error("Extension context invalidated."))).toBe(true);
     expect(isExtensionContextInvalidated("extension context invalidated")).toBe(true);
-    expect(isExtensionContextInvalidated(new Error("storage temporarily unavailable"))).toBe(
-      false,
-    );
+    expect(isExtensionContextInvalidated(new Error("storage temporarily unavailable"))).toBe(false);
     expect(isExtensionContextInvalidated({ message: "Extension context invalidated." })).toBe(
       false,
     );

--- a/tests/extension-context.test.ts
+++ b/tests/extension-context.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createExtensionContextGuard,
+  isExtensionContextInvalidated,
+} from "../src/content/extension-context";
+
+describe("extension context lifecycle", () => {
+  it("recognizes Chrome extension-context invalidation errors", () => {
+    expect(isExtensionContextInvalidated(new Error("Extension context invalidated."))).toBe(true);
+    expect(isExtensionContextInvalidated("extension context invalidated")).toBe(true);
+    expect(isExtensionContextInvalidated(new Error("storage temporarily unavailable"))).toBe(false);
+    expect(isExtensionContextInvalidated({ message: "Extension context invalidated." })).toBe(false);
+  });
+
+  it("turns invalidation into one terminal disposal", () => {
+    const dispose = vi.fn();
+    const guard = createExtensionContextGuard(dispose);
+
+    expect(guard.invalidated).toBe(false);
+    expect(guard.handle(new Error("Extension context invalidated."))).toBe(true);
+    expect(guard.invalidated).toBe(true);
+    expect(dispose).toHaveBeenCalledTimes(1);
+
+    expect(guard.handle(new Error("Extension context invalidated."))).toBe(true);
+    guard.invalidate();
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves genuine operational errors available to normal logging/retry logic", () => {
+    const dispose = vi.fn();
+    const guard = createExtensionContextGuard(dispose);
+
+    expect(guard.handle(new Error("quota exceeded"))).toBe(false);
+    expect(guard.invalidated).toBe(false);
+    expect(dispose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Refs #54

## Result
Stop stale Chat FreePT content-script instances cleanly when Chrome invalidates their extension context after extension reload/disable, eliminating repeated `tab lock heartbeat failed Error: Extension context invalidated` warnings.

## Implementation
Adds a small extension-context guard, makes invalidation terminal/idempotent, stops heartbeat/takeover/navigation loops, disposes the RunController and panel, restores native composer takeover state through panel disposal, and routes controller Chrome-API failures into the same shutdown path. Genuine operational failures remain logged/retried normally.

## Verification
Adds focused invalidation classification/idempotent-disposal regression tests and runs the repository's full hosted PR gates. Existing multi-tab lock, continuation, composer takeover, and setup-guide tests must remain green.

## Risk
Low lifecycle hotfix. No new runtime dependencies, permissions, storage schema changes, host selectors, CI thresholds, or release-policy changes.

## Remaining work
Resolve any hosted CI failures by root cause, preserve the exact CI-built installable artifact, squash merge to `dev`, then repeat the live enable/reload test before any `dev → main` promotion.