### PR TITLE
Isolate conversation state and harden setup walkthrough

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -224,6 +224,9 @@ async function onNavigate(href: string): Promise<void> {
   if (!urlConv && currentConvId.startsWith("pending:")) return;
 
   stopTakeoverRetry();
+  controller?.dispose();
+  controller = null;
+  stopHeartbeat();
   await releaseOwnedLock(currentConvId);
   if (contextGuard.invalidated) return;
   await initConversation(urlConv ?? `pending:${crypto.randomUUID()}`);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -224,9 +224,6 @@ async function onNavigate(href: string): Promise<void> {
   if (!urlConv && currentConvId.startsWith("pending:")) return;
 
   stopTakeoverRetry();
-  if (controller && isActive(controller.state)) {
-    controller.dispatch({ type: "USER_PAUSE" });
-  }
   await releaseOwnedLock(currentConvId);
   if (contextGuard.invalidated) return;
   await initConversation(urlConv ?? `pending:${crypto.randomUUID()}`);

--- a/src/content/run-controller.ts
+++ b/src/content/run-controller.ts
@@ -50,10 +50,16 @@ export class RunController {
     this.onContextInvalidated = hooks.onContextInvalidated ?? (() => undefined);
     this.watcher = new StreamWatcher(
       {
-        onStart: () => this.dispatch({ type: "STREAM_STARTED" }),
+        onStart: () => {
+          if (this.state.status === "sending" || this.state.status === "streaming") {
+            this.dispatch({ type: "STREAM_STARTED" });
+          }
+        },
         onComplete: (text) =>
           this.dispatch({ type: "REPLY_COMPLETE", marker: parseMarker(text), text }),
-        onStuck: () => this.dispatch({ type: "STREAM_STUCK" }),
+        onStuck: () => {
+          if (this.state.status === "streaming") this.dispatch({ type: "STREAM_STUCK" });
+        },
       },
       settings,
     );

--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -23,7 +23,9 @@ export type GuideTargetId =
   | "settingsSecurity"
   | "developerModeRow"
   | "developerModeToggle"
+  | "pluginSearchInput"
   | "pluginAddButton"
+  | "githubMcpPluginResult"
   | "pluginNameInput"
   | "pluginServerInput"
   | "pluginAuthControl"
@@ -234,12 +236,10 @@ const GUIDE_RESOLVERS: Record<GuideTargetId, () => HTMLElement | null> = {
   composerPlusButton,
   settingsSecurity: () => clickableText(/^Security and login$/i),
   developerModeRow,
-  developerModeToggle: () =>
-    controlNearText(
-      /^Developer mode$/i,
-      'button[role="switch"], [role="switch"], input[type="checkbox"]',
-    ),
+  developerModeToggle,
+  pluginSearchInput,
   pluginAddButton,
+  githubMcpPluginResult,
   pluginNameInput: () => fieldNearLabel(/^(Name|Plugin name)$/i, "input"),
   pluginServerInput: () =>
     fieldNearLabel(/(Server URL|Remote MCP|MCP server URL)/i, 'input[type="url"], input'),
@@ -274,11 +274,33 @@ function composerPlusButton(): HTMLElement | null {
   return textElement(/^\+$/i, form, "button") as HTMLElement | null;
 }
 
+function developerModeToggle(): HTMLElement | null {
+  const semantic = document.querySelector<HTMLElement>(
+    'button[role="switch"][aria-label="Developer mode"], [role="switch"][aria-label="Developer mode"]',
+  );
+  if (semantic) return semantic;
+  return controlNearText(
+    /^Developer mode$/i,
+    'button[role="switch"], [role="switch"], input[type="checkbox"]',
+  );
+}
+
 function developerModeRow(): HTMLElement | null {
+  const toggle = developerModeToggle();
+  if (toggle) {
+    let node: HTMLElement | null = toggle;
+    for (let depth = 0; node && depth < 7; depth += 1) {
+      const text = node.textContent ?? "";
+      if (/Allows you to add unverified connectors/i.test(text)) return node;
+      node = node.parentElement;
+    }
+  }
+
   const label = textElement(/^Developer mode$/i);
-  if (!(label instanceof HTMLElement)) return null;
+  if (!(label instanceof HTMLElement)) return toggle;
   let node: HTMLElement | null = label;
   for (let depth = 0; node && depth < 7; depth += 1) {
+    if (toggle && node.contains(toggle)) return node;
     if (node.querySelector('button[role="switch"], [role="switch"], input[type="checkbox"]')) {
       return node;
     }
@@ -287,19 +309,31 @@ function developerModeRow(): HTMLElement | null {
   return label.parentElement ?? label;
 }
 
+function pluginSearchInput(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    '#plugin-search, input[aria-label="Search plugins"], input[placeholder="Search plugins"]',
+  );
+}
+
 function pluginAddButton(): HTMLElement | null {
   const labeled = document.querySelector<HTMLElement>(
-    'button[aria-label*="Add plugin" i], button[aria-label*="Create plugin" i], button[title*="Add plugin" i]',
+    'button[aria-label="Create app"], button[aria-label*="Add plugin" i], button[aria-label*="Create plugin" i], button[title*="Add plugin" i]',
   );
   if (labeled) return labeled;
   const plus = textElement(/^\+$/, document, "button");
   if (plus instanceof HTMLElement) return plus;
-  const search = document.querySelector<HTMLElement>(
-    'input[placeholder*="Search plugin" i], input[type="search"]',
-  );
+  const search = pluginSearchInput();
   const container = search?.parentElement?.parentElement;
   const buttons = container ? Array.from(container.querySelectorAll<HTMLElement>("button")) : [];
   return buttons.at(-1) ?? null;
+}
+
+function githubMcpPluginResult(): HTMLElement | null {
+  const labeled = document.querySelector<HTMLElement>(
+    'a[aria-label="Open GitHub MCP"], button[aria-label="Open GitHub MCP"]',
+  );
+  if (labeled) return labeled;
+  return clickableText(/^GitHub MCP$/i);
 }
 
 function clickableText(pattern: RegExp): HTMLElement | null {

--- a/src/content/stream-watch.ts
+++ b/src/content/stream-watch.ts
@@ -64,8 +64,8 @@ export class StreamWatcher {
     this.baselineElement = message?.el ?? null;
     this.baselineText = message?.text ?? "";
     this.state = "waiting";
-    this.streamStartedAt = Date.now();
-    this.lastMutationAt = this.streamStartedAt;
+    this.streamStartedAt = 0;
+    this.lastMutationAt = Date.now();
     this.settleStartedAt = 0;
     this.stuckReported = false;
     this.replyObserved = false;
@@ -104,7 +104,6 @@ export class StreamWatcher {
   }
 
   private tickWaiting(now: number, stopVisible: boolean): void {
-    this.checkStuck(now);
     if (stopVisible || this.assistantTurnChanged()) {
       this.observeReplyStart(now, stopVisible);
     }
@@ -150,7 +149,7 @@ export class StreamWatcher {
   private observeReplyStart(now: number, stopVisible: boolean): void {
     if (!this.replyObserved) {
       this.replyObserved = true;
-      if (this.streamStartedAt === 0) this.streamStartedAt = now;
+      this.streamStartedAt = now;
       this.stuckReported = false;
       this.callbacks.onStart();
     }
@@ -170,6 +169,7 @@ export class StreamWatcher {
   private checkStuck(now: number): void {
     if (
       !this.stuckReported &&
+      this.replyObserved &&
       this.streamStartedAt > 0 &&
       now - this.streamStartedAt > this.settings.maxStreamMinutes * 60_000
     ) {

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -286,66 +286,76 @@ export class SetupGuide {
   }
 
   private advanceCompletedStep(): boolean {
-    if (this.step === "security" && queryGuideTarget("developerModeToggle")) {
+    return this.advanceSettingsStep() || this.advancePluginStep();
+  }
+
+  private advanceSettingsStep(): boolean {
+    const toggle = queryGuideTarget("developerModeToggle");
+    if (this.step === "security" && toggle) {
       void this.setStep("developer");
       return true;
     }
-
-    if (this.step === "developer" || this.step === "developer-toggle") {
-      const toggle = queryGuideTarget("developerModeToggle");
-      if (toggle && isControlEnabled(toggle)) {
+    if ((this.step === "developer" || this.step === "developer-toggle") && toggle) {
+      if (isControlEnabled(toggle)) {
         void this.setStep("plugins");
         return true;
       }
     }
+    return false;
+  }
 
-    if (this.step === "plugin-search" || this.step === "plugin-add") {
-      if (queryGuideTarget("githubMcpPluginResult")) {
-        this.returnToChat();
-        return true;
-      }
-    }
+  private advancePluginStep(): boolean {
+    if (this.existingPluginCompletesCreation()) return true;
+    return this.advancePluginFormStep();
+  }
 
-    if (this.step === "plugin-search") {
-      const search = queryGuideTarget("pluginSearchInput");
-      if (fieldValue(search).trim().toLowerCase() === SEARCH_VALUE.toLowerCase()) {
-        void this.setStep("plugin-add");
-        return true;
-      }
-    }
+  private existingPluginCompletesCreation(): boolean {
+    if (this.step !== "plugin-search" && this.step !== "plugin-add") return false;
+    if (!queryGuideTarget("githubMcpPluginResult")) return false;
+    this.returnToChat();
+    return true;
+  }
 
-    if (this.step === "plugin-name") {
-      const name = queryGuideTarget("pluginNameInput");
-      if (fieldValue(name).trim().toLowerCase() === SEARCH_VALUE.toLowerCase()) {
-        void this.setStep("plugin-server");
-        return true;
-      }
-    }
-
-    if (this.step === "plugin-server") {
-      const server = queryGuideTarget("pluginServerInput");
-      if (fieldValue(server).trim().replace(/\/$/, "") === MCP_URL.replace(/\/$/, "")) {
-        void this.setStep("plugin-auth");
-        return true;
-      }
-    }
-
-    if (this.step === "plugin-auth") {
-      const auth = queryGuideTarget("pluginAuthControl");
-      if (controlValue(auth).includes("oauth")) {
+  private advancePluginFormStep(): boolean {
+    switch (this.step) {
+      case "plugin-search":
+        return this.advanceWhenFieldMatches("pluginSearchInput", SEARCH_VALUE, "plugin-add");
+      case "plugin-name":
+        return this.advanceWhenFieldMatches("pluginNameInput", SEARCH_VALUE, "plugin-server");
+      case "plugin-server":
+        return this.advanceWhenFieldMatches("pluginServerInput", MCP_URL, "plugin-auth", true);
+      case "plugin-auth": {
+        const auth = queryGuideTarget("pluginAuthControl");
+        if (!controlValue(auth).includes("oauth")) return false;
         void this.setStep("plugin-risk");
         return true;
       }
-    }
-
-    if (this.step === "plugin-risk") {
-      const risk = queryGuideTarget("pluginRiskCheckbox");
-      if (risk && isControlEnabled(risk)) {
+      case "plugin-risk": {
+        const risk = queryGuideTarget("pluginRiskCheckbox");
+        if (!risk || !isControlEnabled(risk)) return false;
         void this.setStep("plugin-create");
         return true;
       }
+      default:
+        return false;
     }
-    return false;
+  }
+
+  private advanceWhenFieldMatches(
+    id: GuideTargetId,
+    expected: string,
+    next: SetupGuideStep,
+    ignoreTrailingSlash = false,
+  ): boolean {
+    let actual = fieldValue(queryGuideTarget(id)).trim();
+    let target = expected;
+    if (ignoreTrailingSlash) {
+      actual = actual.replace(/\/$/, "");
+      target = target.replace(/\/$/, "");
+    }
+    if (actual.toLowerCase() !== target.toLowerCase()) return false;
+    void this.setStep(next);
+    return true;
   }
 
   private hide(): void {

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -681,7 +681,9 @@ function controlValue(element: HTMLElement | null): string {
 
 function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
   const prototype =
-    element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+    element instanceof HTMLInputElement
+      ? HTMLInputElement.prototype
+      : HTMLTextAreaElement.prototype;
   const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
   if (setter) setter.call(element, value);
   else element.value = value;
@@ -697,7 +699,8 @@ function settingsScrollContainer(target: HTMLElement): HTMLElement | null {
     node = node.parentElement;
   }
 
-  const modal = target.closest<HTMLElement>("#modal-settings") ?? document.getElementById("modal-settings");
+  const modal =
+    target.closest<HTMLElement>("#modal-settings") ?? document.getElementById("modal-settings");
   return modal?.querySelector<HTMLElement>('[class*="overflow-y-auto"]') ?? null;
 }
 

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -5,6 +5,7 @@ export type SetupGuideStep =
   | "developer"
   | "developer-toggle"
   | "plugins"
+  | "plugin-search"
   | "plugin-add"
   | "plugin-name"
   | "plugin-server"
@@ -29,9 +30,30 @@ interface GuideCopy {
   actions: string;
 }
 
-const STORAGE_KEY = "cfpt:setup-guide:v1";
+const SESSION_KEY = "cfpt:setup-guide:v2";
 const MCP_URL = "https://api.githubcopilot.com/mcp/";
 const PLUGINS_URL = "https://chatgpt.com/plugins";
+const SEARCH_VALUE = "GitHub MCP";
+const SCROLL_RETRY_MS = 150;
+
+const GUIDE_STEPS = new Set<SetupGuideStep>([
+  "security",
+  "developer",
+  "developer-toggle",
+  "plugins",
+  "plugin-search",
+  "plugin-add",
+  "plugin-name",
+  "plugin-server",
+  "plugin-auth",
+  "plugin-risk",
+  "plugin-create",
+  "oauth",
+  "chat-plus",
+  "developer-menu",
+  "github-app",
+  "done",
+]);
 
 const GUIDE_CSS = `
 :host {
@@ -108,6 +130,7 @@ const TARGETS: Partial<Record<SetupGuideStep, GuideTargetId>> = {
   security: "settingsSecurity",
   developer: "developerModeRow",
   "developer-toggle": "developerModeToggle",
+  "plugin-search": "pluginSearchInput",
   "plugin-add": "pluginAddButton",
   "plugin-name": "pluginNameInput",
   "plugin-server": "pluginServerInput",
@@ -124,6 +147,7 @@ const EARLY_COPY_STEPS = new Set<SetupGuideStep>([
   "developer",
   "developer-toggle",
   "plugins",
+  "plugin-search",
   "plugin-add",
   "plugin-name",
   "plugin-server",
@@ -140,6 +164,7 @@ export class SetupGuide {
   private step: SetupGuideStep = "security";
   private returnUrl = "https://chatgpt.com/";
   private lastScrolledStep: SetupGuideStep | null = null;
+  private lastScrollAttemptAt = 0;
   private disposed = false;
 
   constructor() {
@@ -167,15 +192,15 @@ export class SetupGuide {
     window.addEventListener("scroll", this.onViewportChange, true);
     this.observer = new MutationObserver(() => this.render());
     this.observer.observe(document.documentElement, { childList: true, subtree: true });
-    void this.restore();
+    this.restore();
   }
 
   async start(): Promise<void> {
     this.active = true;
     this.step = "security";
     this.returnUrl = chatReturnUrl();
-    this.lastScrolledStep = null;
-    await this.persist();
+    this.resetScrollTracking();
+    this.persist();
     this.render();
     openSettings();
   }
@@ -183,7 +208,7 @@ export class SetupGuide {
   async cancel(): Promise<void> {
     this.active = false;
     this.hide();
-    await this.persist();
+    this.persist();
   }
 
   dispose(): void {
@@ -205,10 +230,10 @@ export class SetupGuide {
     this.afterTargetClick(target);
   };
 
-  private async restore(): Promise<void> {
+  private restore(): void {
     try {
-      const stored = await chrome.storage.local.get(STORAGE_KEY);
-      const value = stored[STORAGE_KEY] as Partial<StoredGuide> | undefined;
+      const raw = window.sessionStorage.getItem(SESSION_KEY);
+      const value = raw ? (JSON.parse(raw) as Partial<StoredGuide>) : undefined;
       if (value?.active === true && isGuideStep(value.step)) {
         this.active = true;
         this.step = value.step;
@@ -220,16 +245,16 @@ export class SetupGuide {
     if (!this.disposed) this.render();
   }
 
-  private async persist(): Promise<void> {
+  private persist(): void {
     try {
       const value: StoredGuide = {
         active: this.active,
         step: this.step,
         returnUrl: this.returnUrl,
       };
-      await chrome.storage.local.set({ [STORAGE_KEY]: value });
+      window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(value));
     } catch {
-      // The guide remains usable for the current page even if persistence is unavailable.
+      // The guide remains usable for the current page even if tab-session persistence fails.
     }
   }
 
@@ -248,17 +273,79 @@ export class SetupGuide {
       this.hide();
       return;
     }
+    if (this.advanceCompletedStep()) return;
 
     const target = this.currentTarget();
-    if (target) {
-      this.positionRing(target);
-      this.maybeScrollTarget(target);
-    } else {
-      this.ring.classList.add("cfpt-guide-hidden");
-    }
+    const targetReady = target ? this.ensureTargetVisible(target) : false;
+    if (target && targetReady) this.positionRing(target);
+    else this.ring.classList.add("cfpt-guide-hidden");
+
     this.card.innerHTML = this.cardHtml(Boolean(target));
     this.card.classList.remove("cfpt-guide-hidden");
-    this.positionCard(target);
+    this.positionCard(targetReady ? target : null);
+  }
+
+  private advanceCompletedStep(): boolean {
+    if (this.step === "security" && queryGuideTarget("developerModeToggle")) {
+      void this.setStep("developer");
+      return true;
+    }
+
+    if (this.step === "developer" || this.step === "developer-toggle") {
+      const toggle = queryGuideTarget("developerModeToggle");
+      if (toggle && isControlEnabled(toggle)) {
+        void this.setStep("plugins");
+        return true;
+      }
+    }
+
+    if (this.step === "plugin-search" || this.step === "plugin-add") {
+      if (queryGuideTarget("githubMcpPluginResult")) {
+        this.returnToChat();
+        return true;
+      }
+    }
+
+    if (this.step === "plugin-search") {
+      const search = queryGuideTarget("pluginSearchInput");
+      if (fieldValue(search).trim().toLowerCase() === SEARCH_VALUE.toLowerCase()) {
+        void this.setStep("plugin-add");
+        return true;
+      }
+    }
+
+    if (this.step === "plugin-name") {
+      const name = queryGuideTarget("pluginNameInput");
+      if (fieldValue(name).trim().toLowerCase() === SEARCH_VALUE.toLowerCase()) {
+        void this.setStep("plugin-server");
+        return true;
+      }
+    }
+
+    if (this.step === "plugin-server") {
+      const server = queryGuideTarget("pluginServerInput");
+      if (fieldValue(server).trim().replace(/\/$/, "") === MCP_URL.replace(/\/$/, "")) {
+        void this.setStep("plugin-auth");
+        return true;
+      }
+    }
+
+    if (this.step === "plugin-auth") {
+      const auth = queryGuideTarget("pluginAuthControl");
+      if (controlValue(auth).includes("oauth")) {
+        void this.setStep("plugin-risk");
+        return true;
+      }
+    }
+
+    if (this.step === "plugin-risk") {
+      const risk = queryGuideTarget("pluginRiskCheckbox");
+      if (risk && isControlEnabled(risk)) {
+        void this.setStep("plugin-create");
+        return true;
+      }
+    }
+    return false;
   }
 
   private hide(): void {
@@ -302,13 +389,26 @@ export class SetupGuide {
     });
   }
 
-  private maybeScrollTarget(target: HTMLElement): void {
-    if (this.lastScrolledStep === this.step) return;
-    if (this.step !== "developer" && this.step !== "developer-toggle") return;
-    this.lastScrolledStep = this.step;
-    if (typeof target.scrollIntoView === "function") {
-      target.scrollIntoView({ behavior: "smooth", block: "center" });
+  private ensureTargetVisible(target: HTMLElement): boolean {
+    if (this.step !== "developer" && this.step !== "developer-toggle") return true;
+    if (this.lastScrolledStep === this.step) return true;
+
+    const container = settingsScrollContainer(target);
+    if (isVisibleWithin(target, container)) {
+      this.lastScrolledStep = this.step;
+      return true;
     }
+
+    const now = Date.now();
+    if (now - this.lastScrollAttemptAt < SCROLL_RETRY_MS) return false;
+    this.lastScrollAttemptAt = now;
+
+    if (container) centerInScrollContainer(target, container);
+    else if (typeof target.scrollIntoView === "function") {
+      target.scrollIntoView({ behavior: "auto", block: "center", inline: "nearest" });
+    }
+    requestAnimationFrame(() => this.render());
+    return false;
   }
 
   private afterTargetClick(target: HTMLElement): void {
@@ -351,9 +451,14 @@ export class SetupGuide {
 
   private async setStep(step: SetupGuideStep): Promise<void> {
     this.step = step;
-    this.lastScrolledStep = null;
-    await this.persist();
+    this.resetScrollTracking();
+    this.persist();
     this.render();
+  }
+
+  private resetScrollTracking(): void {
+    this.lastScrolledStep = null;
+    this.lastScrollAttemptAt = 0;
   }
 
   private onGuideClick(event: Event): void {
@@ -364,8 +469,9 @@ export class SetupGuide {
     if (action === "cancel") void this.cancel();
     else if (action === "developer-next") void this.setStep("developer-toggle");
     else if (action === "open-plugins") this.openPlugins();
+    else if (action === "search-plugin") this.searchForPlugin();
     else if (action === "fill-name") {
-      this.fillField("pluginNameInput", "GitHub MCP", "plugin-server");
+      this.fillField("pluginNameInput", SEARCH_VALUE, "plugin-server");
     } else if (action === "fill-url") {
       this.fillField("pluginServerInput", MCP_URL, "plugin-auth");
     } else if (action === "auth-next") void this.setStep("plugin-risk");
@@ -375,7 +481,14 @@ export class SetupGuide {
   }
 
   private openPlugins(): void {
-    void this.setStep("plugin-add").then(() => navigate(PLUGINS_URL));
+    void this.setStep("plugin-search").then(() => navigate(PLUGINS_URL));
+  }
+
+  private searchForPlugin(): void {
+    const search = queryGuideTarget("pluginSearchInput");
+    if (!(search instanceof HTMLInputElement || search instanceof HTMLTextAreaElement)) return;
+    setNativeValue(search, SEARCH_VALUE);
+    setTimeout(() => void this.setStep("plugin-add"), 250);
   }
 
   private fillField(id: GuideTargetId, value: string, next: SetupGuideStep): void {
@@ -397,7 +510,7 @@ export class SetupGuide {
   private async finish(): Promise<void> {
     this.step = "done";
     this.active = false;
-    await this.persist();
+    this.persist();
     this.hide();
   }
 
@@ -427,37 +540,46 @@ function guideCopyEarly(step: SetupGuideStep, wait: string): GuideCopy {
     case "developer":
       return copy(
         "2 · Developer mode",
-        `Developer mode is lower on this page. I’ve brought the highlighted row into view.${wait}`,
+        `Developer mode is lower on this page. I’ll bring the row into the Settings viewport before highlighting it.${wait}`,
         primary("developer-next", "Show the switch"),
       );
     case "developer-toggle":
       return copy(
         "3 · Enable Developer mode",
-        `Turn on the highlighted <b>Developer mode</b> switch. ChatGPT labels this Elevated Risk because it permits unverified connectors.${wait}`,
+        `Turn on the highlighted <b>Developer mode</b> switch. If it is already on, the guide skips this step automatically.${wait}`,
       );
     case "plugins":
       return copy(
         "4 · Open Plugins",
-        "Developer mode is on. Continue to ChatGPT Plugins to add the official remote GitHub MCP endpoint.",
+        "Developer mode is ready. Continue to ChatGPT Plugins; the guide checks for an existing GitHub MCP before asking you to create one.",
         primary("open-plugins", "Open Plugins"),
       );
+    case "plugin-search":
+      return copy(
+        "5 · Check for GitHub MCP",
+        `Search for <b>${SEARCH_VALUE}</b>. If your developer app already exists, the guide will reuse it.${wait}`,
+        primary("search-plugin", "Search GitHub MCP"),
+      );
     case "plugin-add":
-      return copy("5 · Add a plugin", `Click the highlighted <b>+</b> button.${wait}`);
+      return copy(
+        "6 · Create the app",
+        `No existing <b>GitHub MCP</b> app was found. Click the highlighted <b>Create app</b> button.${wait}`,
+      );
     case "plugin-name":
       return copy(
-        "6 · Name",
-        `Use <b>GitHub MCP</b> so it is easy to recognize later.${wait}`,
-        primary("fill-name", "Use GitHub MCP"),
+        "7 · Name",
+        `Use <b>${SEARCH_VALUE}</b> so it is easy to recognize later.${wait}`,
+        primary("fill-name", `Use ${SEARCH_VALUE}`),
       );
     case "plugin-server":
       return copy(
-        "7 · Server URL",
+        "8 · Server URL",
         `Put <code>${MCP_URL}</code> in the highlighted Server URL field.${wait}`,
         primary("fill-url", "Fill server URL"),
       );
     case "plugin-auth":
       return copy(
-        "8 · Authentication",
+        "9 · Authentication",
         `Set Authentication to <b>OAuth</b> in the highlighted control.${wait}`,
         primary("auth-next", "OAuth selected — next"),
       );
@@ -470,31 +592,31 @@ function guideCopyLate(step: SetupGuideStep, wait: string): GuideCopy {
   switch (step) {
     case "plugin-risk":
       return copy(
-        "9 · Risk acknowledgement",
+        "10 · Risk acknowledgement",
         `Read the warning, then check the highlighted acknowledgement.${wait}`,
         primary("risk-next", "Checked — next"),
       );
     case "plugin-create":
-      return copy("10 · Create", `Click the highlighted <b>Create</b> button.${wait}`);
+      return copy("11 · Create", `Click the highlighted <b>Create</b> button.${wait}`);
     case "oauth":
       return copy(
-        "11 · Complete GitHub OAuth",
+        "12 · Complete GitHub OAuth",
         "Finish the GitHub authorization ChatGPT opens. Approve the repository and workflow write permissions you intend Chat FreePT to use, then return here.",
         primary("return-chat", "Connected — return to chat"),
       );
     case "chat-plus":
       return copy(
-        "12 · Add it to this chat",
+        "13 · Add it to this chat",
         `Click the highlighted <b>+</b> beside the composer.${wait}`,
       );
     case "developer-menu":
       return copy(
-        "13 · Developer mode",
+        "14 · Developer mode",
         `Choose the highlighted <b>Developer mode</b> entry. If GitHub MCP appears directly, choose it instead.${wait}`,
       );
     case "github-app":
       return copy(
-        "14 · GitHub MCP",
+        "15 · GitHub MCP",
         `Choose the highlighted <b>GitHub MCP</b> plugin for this conversation.${wait}`,
       );
     case "done":
@@ -521,9 +643,7 @@ function primary(action: string, label: string): string {
 }
 
 function isGuideStep(value: unknown): value is SetupGuideStep {
-  return typeof value === "string" && Object.prototype.hasOwnProperty.call(TARGETS, value)
-    ? true
-    : value === "plugins" || value === "oauth" || value === "done";
+  return typeof value === "string" && GUIDE_STEPS.has(value as SetupGuideStep);
 }
 
 function isControlEnabled(element: HTMLElement): boolean {
@@ -534,16 +654,57 @@ function isControlEnabled(element: HTMLElement): boolean {
   );
 }
 
+function fieldValue(element: HTMLElement | null): string {
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    return element.value;
+  }
+  return "";
+}
+
+function controlValue(element: HTMLElement | null): string {
+  if (!element) return "";
+  if (element instanceof HTMLSelectElement || element instanceof HTMLInputElement) {
+    return element.value.toLowerCase();
+  }
+  return `${element.getAttribute("data-value") ?? ""} ${element.textContent ?? ""}`.toLowerCase();
+}
+
 function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
   const prototype =
-    element instanceof HTMLInputElement
-      ? HTMLInputElement.prototype
-      : HTMLTextAreaElement.prototype;
+    element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
   const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
   if (setter) setter.call(element, value);
   else element.value = value;
   element.dispatchEvent(new Event("input", { bubbles: true }));
   element.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function settingsScrollContainer(target: HTMLElement): HTMLElement | null {
+  let node = target.parentElement;
+  while (node && node !== document.body) {
+    const style = getComputedStyle(node);
+    if (/(auto|scroll)/.test(style.overflowY) && node.scrollHeight > node.clientHeight) return node;
+    node = node.parentElement;
+  }
+
+  const modal = target.closest<HTMLElement>("#modal-settings") ?? document.getElementById("modal-settings");
+  return modal?.querySelector<HTMLElement>('[class*="overflow-y-auto"]') ?? null;
+}
+
+function isVisibleWithin(target: HTMLElement, container: HTMLElement | null): boolean {
+  const targetRect = target.getBoundingClientRect();
+  const boundary = container?.getBoundingClientRect();
+  const top = boundary && boundary.height > 0 ? boundary.top : 0;
+  const bottom = boundary && boundary.height > 0 ? boundary.bottom : window.innerHeight;
+  return targetRect.bottom > top + 8 && targetRect.top < bottom - 8;
+}
+
+function centerInScrollContainer(target: HTMLElement, container: HTMLElement): void {
+  const targetRect = target.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+  const height = container.clientHeight || containerRect.height;
+  const offset = targetRect.top - containerRect.top - Math.max(0, (height - targetRect.height) / 2);
+  container.scrollTop += offset;
 }
 
 function chatReturnUrl(): string {
@@ -564,6 +725,6 @@ function navigate(url: string): void {
   try {
     window.location.assign(url);
   } catch {
-    // JSDOM/test environments do not implement navigation; the persisted step still survives.
+    // JSDOM/test environments do not implement navigation; tab-session state still survives.
   }
 }

--- a/tests/run-controller.test.ts
+++ b/tests/run-controller.test.ts
@@ -320,3 +320,34 @@ describe("RunController recovery and disposal", () => {
     controller.dispose();
   });
 });
+
+describe("RunController stale stream isolation", () => {
+  it("keeps NEEDS_INPUT stable when stale start and stuck signals arrive", () => {
+    const controller = makeController(streamingState());
+
+    watcher().callbacks.onComplete("CHATFREEPT_STATUS: NEEDS_INPUT\nNOTE: wait for approval");
+    expect(controller.state.status).toBe("awaiting_user");
+
+    watcher().callbacks.onStart();
+    watcher().callbacks.onStuck();
+
+    expect(controller.state.status).toBe("awaiting_user");
+    expect(controller.state.errorCode).toBeUndefined();
+    controller.dispose();
+  });
+
+  it("keeps auto-continue-off waiting stable when stale stream signals arrive", () => {
+    const controller = makeController(streamingState());
+    controller.dispatch({ type: "USER_SET_AUTO_CONTINUE", enabled: false });
+
+    watcher().callbacks.onComplete("CHATFREEPT_STATUS: CONTINUE\nV: 1");
+    expect(controller.state.status).toBe("awaiting_user");
+
+    watcher().callbacks.onStart();
+    watcher().callbacks.onStuck();
+
+    expect(controller.state.status).toBe("awaiting_user");
+    expect(controller.state.errorCode).toBeUndefined();
+    controller.dispose();
+  });
+});

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -145,29 +145,56 @@ describe("composer and guided-setup targets", () => {
     expect(queryGuideTarget("composerPlusButton")?.dataset["testid"]).toBe("composer-plus-btn");
   });
 
-  it("resolves Security and login, Developer mode row, and its switch", () => {
+  it("resolves Security and login, Developer mode row, and its semantic switch", () => {
     document.body.innerHTML = `
       <nav><button>Security and login</button></nav>
       <section class="developer-row">
         <div><strong>Developer mode</strong><span>Elevated Risk</span></div>
+        <div>Allows you to add unverified connectors that could modify or erase data permanently.</div>
         <button role="switch" aria-checked="false" aria-label="Developer mode"></button>
+      </section>
+      <section>
+        <span>Enforce CSP in developer mode</span>
+        <button role="switch" aria-checked="true" aria-label="Enforce CSP in developer mode"></button>
       </section>`;
 
     expect(queryGuideTarget("settingsSecurity")?.textContent).toContain("Security and login");
     expect(queryGuideTarget("developerModeRow")?.classList.contains("developer-row")).toBe(true);
-    expect(queryGuideTarget("developerModeToggle")?.getAttribute("role")).toBe("switch");
+    expect(queryGuideTarget("developerModeToggle")?.getAttribute("aria-label")).toBe("Developer mode");
   });
 
-  it("resolves every field in the New Plugin form", () => {
+  it("resolves the current Plugins search, Create app button, and only exact GitHub MCP result", () => {
     document.body.innerHTML = `
-      <button aria-label="Add plugin">+</button>
+      <input id="plugin-search" placeholder="Search plugins" aria-label="Search plugins" value="GitHub" />
+      <button aria-label="Create app"></button>
+      <article><a aria-label="Open GitHub" href="/plugins/public-github">GitHub</a></article>
+      <article><a aria-label="Open GitHub MCP" href="/plugins/custom-github-mcp">GitHub MCP</a></article>`;
+
+    expect(queryGuideTarget("pluginSearchInput")?.id).toBe("plugin-search");
+    expect(queryGuideTarget("pluginAddButton")?.getAttribute("aria-label")).toBe("Create app");
+    expect(queryGuideTarget("githubMcpPluginResult")?.getAttribute("aria-label")).toBe(
+      "Open GitHub MCP",
+    );
+  });
+
+  it("does not mistake the public GitHub plugin for a custom GitHub MCP app", () => {
+    document.body.innerHTML = `
+      <input id="plugin-search" aria-label="Search plugins" value="GitHub" />
+      <article><a aria-label="Open GitHub" href="/plugins/public-github">GitHub</a></article>`;
+
+    expect(queryGuideTarget("githubMcpPluginResult")).toBeNull();
+  });
+
+  it("resolves every field in the developer app form", () => {
+    document.body.innerHTML = `
+      <button aria-label="Create app">+</button>
       <label for="plugin-name">Name</label><input id="plugin-name" />
       <label for="server-url">Server URL</label><input id="server-url" type="url" />
       <label for="auth">Authentication</label><select id="auth"><option>OAuth</option></select>
       <label><span>I understand the risks and want to continue</span><input id="risk" type="checkbox" /></label>
       <button>Create</button>`;
 
-    expect(queryGuideTarget("pluginAddButton")?.getAttribute("aria-label")).toBe("Add plugin");
+    expect(queryGuideTarget("pluginAddButton")?.getAttribute("aria-label")).toBe("Create app");
     expect(queryGuideTarget("pluginNameInput")?.id).toBe("plugin-name");
     expect(queryGuideTarget("pluginServerInput")?.id).toBe("server-url");
     expect(queryGuideTarget("pluginAuthControl")?.id).toBe("auth");

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -160,7 +160,9 @@ describe("composer and guided-setup targets", () => {
 
     expect(queryGuideTarget("settingsSecurity")?.textContent).toContain("Security and login");
     expect(queryGuideTarget("developerModeRow")?.classList.contains("developer-row")).toBe(true);
-    expect(queryGuideTarget("developerModeToggle")?.getAttribute("aria-label")).toBe("Developer mode");
+    expect(queryGuideTarget("developerModeToggle")?.getAttribute("aria-label")).toBe(
+      "Developer mode",
+    );
   });
 
   it("resolves the current Plugins search, Create app button, and only exact GitHub MCP result", () => {

--- a/tests/setup-guide.test.ts
+++ b/tests/setup-guide.test.ts
@@ -50,7 +50,7 @@ afterEach(() => {
   window.sessionStorage.clear();
 });
 
-describe("opt-in setup guide", () => {
+describe("setup guide tab isolation", () => {
   it("keeps walkthrough progress in this tab session instead of extension-wide storage", async () => {
     stores.local["cfpt:setup-guide:v1"] = {
       active: true,
@@ -68,7 +68,7 @@ describe("opt-in setup guide", () => {
     expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ step: "developer-toggle" });
   });
 
-  it("highlights only Security and login, then advances in the same tab session", async () => {
+  it("highlights Security and login, then advances in the same tab session", async () => {
     stored("security");
     document.body.innerHTML = '<button id="security">Security and login</button>';
     makeGuide();
@@ -85,7 +85,26 @@ describe("opt-in setup guide", () => {
     expect(ring?.classList.contains("cfpt-guide-hidden")).toBe(true);
   });
 
-  it("scrolls the settings content region before highlighting off-screen Developer mode", async () => {
+  it("keeps cancellation local to this tab session", async () => {
+    stored("security");
+    document.body.innerHTML = '<button id="security">Security and login</button>';
+    makeGuide();
+    await settle();
+
+    shadow.querySelector<HTMLButtonElement>('[data-guide-action="cancel"]')?.click();
+    await settle();
+    expect(sessionState()).toMatchObject({ active: false });
+    expect(shadow.querySelector(".cfpt-guide-ring")?.classList.contains("cfpt-guide-hidden")).toBe(
+      true,
+    );
+    expect(shadow.querySelector(".cfpt-guide-card")?.classList.contains("cfpt-guide-hidden")).toBe(
+      true,
+    );
+  });
+});
+
+describe("setup guide settings flow", () => {
+  it("scrolls settings before highlighting off-screen Developer mode", async () => {
     stored("developer");
     document.body.innerHTML = `
       <div id="modal-settings">
@@ -104,9 +123,29 @@ describe("opt-in setup guide", () => {
       scrollHeight: { configurable: true, value: 1200 },
     });
     scroller.getBoundingClientRect = () =>
-      ({ top: 100, bottom: 500, height: 400, left: 0, right: 600, width: 600, x: 0, y: 100, toJSON: () => ({}) }) as DOMRect;
+      ({
+        top: 100,
+        bottom: 500,
+        height: 400,
+        left: 0,
+        right: 600,
+        width: 600,
+        x: 0,
+        y: 100,
+        toJSON: () => ({}),
+      }) as DOMRect;
     row.getBoundingClientRect = () =>
-      ({ top: 850, bottom: 920, height: 70, left: 100, right: 550, width: 450, x: 100, y: 850, toJSON: () => ({}) }) as DOMRect;
+      ({
+        top: 850,
+        bottom: 920,
+        height: 70,
+        left: 100,
+        right: 550,
+        width: 450,
+        x: 100,
+        y: 850,
+        toJSON: () => ({}),
+      }) as DOMRect;
 
     makeGuide();
     await settle();
@@ -129,7 +168,7 @@ describe("opt-in setup guide", () => {
     expect(shadow.textContent).toContain("4 · Open Plugins");
   });
 
-  it("advances only after a disabled Developer mode switch becomes enabled", async () => {
+  it("advances after a disabled Developer mode switch becomes enabled", async () => {
     stored("developer-toggle");
     document.body.innerHTML = `
       <section>
@@ -146,7 +185,9 @@ describe("opt-in setup guide", () => {
     await settle(150);
     expect(sessionState()).toMatchObject({ step: "plugins" });
   });
+});
 
+describe("setup guide plugin flow", () => {
   it("searches for the exact custom GitHub MCP app before offering Create app", async () => {
     stored("plugin-search");
     document.body.innerHTML = `
@@ -193,22 +234,5 @@ describe("opt-in setup guide", () => {
     expect(inputEvent).toHaveBeenCalledTimes(1);
     expect(changeEvent).toHaveBeenCalledTimes(1);
     expect(sessionState()).toMatchObject({ step: "plugin-auth" });
-  });
-
-  it("removes the current highlight and keeps cancellation local to the tab", async () => {
-    stored("security");
-    document.body.innerHTML = '<button id="security">Security and login</button>';
-    makeGuide();
-    await settle();
-
-    shadow.querySelector<HTMLButtonElement>('[data-guide-action="cancel"]')?.click();
-    await settle();
-    expect(sessionState()).toMatchObject({ active: false });
-    expect(shadow.querySelector(".cfpt-guide-ring")?.classList.contains("cfpt-guide-hidden")).toBe(
-      true,
-    );
-    expect(shadow.querySelector(".cfpt-guide-card")?.classList.contains("cfpt-guide-hidden")).toBe(
-      true,
-    );
   });
 });

--- a/tests/setup-guide.test.ts
+++ b/tests/setup-guide.test.ts
@@ -2,17 +2,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SetupGuide } from "../src/content/ui/setup-guide";
 import { installChromeMock } from "./chrome-mock";
 
+const SESSION_KEY = "cfpt:setup-guide:v2";
 let stores: ReturnType<typeof installChromeMock>;
 let shadow: ShadowRoot;
 let attachShadowSpy: ReturnType<typeof vi.spyOn>;
 let guide: SetupGuide | undefined;
 
 function stored(step: string): void {
-  stores.local["cfpt:setup-guide:v1"] = {
-    active: true,
-    step,
-    returnUrl: "https://chatgpt.com/c/example",
-  };
+  window.sessionStorage.setItem(
+    SESSION_KEY,
+    JSON.stringify({ active: true, step, returnUrl: "https://chatgpt.com/c/example" }),
+  );
+}
+
+function sessionState(): Record<string, unknown> | null {
+  const raw = window.sessionStorage.getItem(SESSION_KEY);
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
 }
 
 function makeGuide(): SetupGuide {
@@ -26,6 +31,7 @@ async function settle(ms = 0): Promise<void> {
 
 beforeEach(() => {
   stores = installChromeMock();
+  window.sessionStorage.clear();
   document.body.innerHTML = "";
   const original = HTMLElement.prototype.attachShadow;
   attachShadowSpy = vi.spyOn(HTMLElement.prototype, "attachShadow").mockImplementation(function (
@@ -41,10 +47,28 @@ afterEach(() => {
   guide?.dispose();
   guide = undefined;
   attachShadowSpy.mockRestore();
+  window.sessionStorage.clear();
 });
 
 describe("opt-in setup guide", () => {
-  it("highlights only Security and login, then clears it for the next step", async () => {
+  it("keeps walkthrough progress in this tab session instead of extension-wide storage", async () => {
+    stores.local["cfpt:setup-guide:v1"] = {
+      active: true,
+      step: "developer-toggle",
+      returnUrl: "https://chatgpt.com/c/other-tab",
+    };
+    document.body.innerHTML = '<button id="security">Security and login</button>';
+    makeGuide();
+    await settle();
+
+    expect(shadow.querySelector(".cfpt-guide-card")?.classList.contains("cfpt-guide-hidden")).toBe(
+      true,
+    );
+    expect(window.sessionStorage.getItem(SESSION_KEY)).toBeNull();
+    expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ step: "developer-toggle" });
+  });
+
+  it("highlights only Security and login, then advances in the same tab session", async () => {
     stored("security");
     document.body.innerHTML = '<button id="security">Security and login</button>';
     makeGuide();
@@ -57,16 +81,60 @@ describe("opt-in setup guide", () => {
 
     document.getElementById("security")?.click();
     await settle(100);
-    expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ step: "developer" });
+    expect(sessionState()).toMatchObject({ step: "developer" });
     expect(ring?.classList.contains("cfpt-guide-hidden")).toBe(true);
   });
 
-  it("advances only after the Developer mode switch becomes enabled", async () => {
+  it("scrolls the settings content region before highlighting off-screen Developer mode", async () => {
+    stored("developer");
+    document.body.innerHTML = `
+      <div id="modal-settings">
+        <div id="settings-scroll" class="overflow-y-auto" style="overflow-y:auto">
+          <div id="developer-row">
+            <div>Developer mode</div>
+            <div>Allows you to add unverified connectors that could modify or erase data permanently.</div>
+            <button role="switch" aria-label="Developer mode" aria-checked="false"></button>
+          </div>
+        </div>
+      </div>`;
+    const scroller = document.getElementById("settings-scroll") as HTMLElement;
+    const row = document.getElementById("developer-row") as HTMLElement;
+    Object.defineProperties(scroller, {
+      clientHeight: { configurable: true, value: 400 },
+      scrollHeight: { configurable: true, value: 1200 },
+    });
+    scroller.getBoundingClientRect = () =>
+      ({ top: 100, bottom: 500, height: 400, left: 0, right: 600, width: 600, x: 0, y: 100, toJSON: () => ({}) }) as DOMRect;
+    row.getBoundingClientRect = () =>
+      ({ top: 850, bottom: 920, height: 70, left: 100, right: 550, width: 450, x: 100, y: 850, toJSON: () => ({}) }) as DOMRect;
+
+    makeGuide();
+    await settle();
+
+    expect(scroller.scrollTop).toBeGreaterThan(0);
+    expect(shadow.textContent).toContain("Developer mode is lower on this page");
+  });
+
+  it("skips Developer mode when the semantic switch is already enabled", async () => {
     stored("developer-toggle");
     document.body.innerHTML = `
       <section>
         <span>Developer mode</span>
-        <button id="developer-switch" role="switch" aria-checked="false"></button>
+        <button role="switch" aria-label="Developer mode" aria-checked="true"></button>
+      </section>`;
+    makeGuide();
+    await settle();
+
+    expect(sessionState()).toMatchObject({ step: "plugins" });
+    expect(shadow.textContent).toContain("4 · Open Plugins");
+  });
+
+  it("advances only after a disabled Developer mode switch becomes enabled", async () => {
+    stored("developer-toggle");
+    document.body.innerHTML = `
+      <section>
+        <span>Developer mode</span>
+        <button id="developer-switch" role="switch" aria-label="Developer mode" aria-checked="false"></button>
       </section>`;
     const toggle = document.getElementById("developer-switch");
     toggle?.addEventListener("click", () => toggle.setAttribute("aria-checked", "true"));
@@ -76,7 +144,34 @@ describe("opt-in setup guide", () => {
     expect(shadow.textContent).toContain("3 · Enable Developer mode");
     toggle?.click();
     await settle(150);
-    expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ step: "plugins" });
+    expect(sessionState()).toMatchObject({ step: "plugins" });
+  });
+
+  it("searches for the exact custom GitHub MCP app before offering Create app", async () => {
+    stored("plugin-search");
+    document.body.innerHTML = `
+      <input id="plugin-search" aria-label="Search plugins" value="GitHub" />
+      <button aria-label="Create app"></button>`;
+    makeGuide();
+    await settle();
+
+    shadow.querySelector<HTMLButtonElement>('[data-guide-action="search-plugin"]')?.click();
+    await settle(300);
+
+    expect((document.getElementById("plugin-search") as HTMLInputElement).value).toBe("GitHub MCP");
+    expect(sessionState()).toMatchObject({ step: "plugin-add" });
+    expect(shadow.textContent).toContain("Create the app");
+  });
+
+  it("skips custom app creation when an existing GitHub MCP result is present", async () => {
+    stored("plugin-add");
+    document.body.innerHTML = `
+      <input id="plugin-search" aria-label="Search plugins" value="GitHub MCP" />
+      <article><a aria-label="Open GitHub MCP" href="/plugins/custom-github-mcp">GitHub MCP</a></article>`;
+    makeGuide();
+    await settle();
+
+    expect(sessionState()).toMatchObject({ step: "chat-plus" });
   });
 
   it("fills the exact GitHub MCP server URL using native input events", async () => {
@@ -97,10 +192,10 @@ describe("opt-in setup guide", () => {
     expect(input.value).toBe("https://api.githubcopilot.com/mcp/");
     expect(inputEvent).toHaveBeenCalledTimes(1);
     expect(changeEvent).toHaveBeenCalledTimes(1);
-    expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ step: "plugin-auth" });
+    expect(sessionState()).toMatchObject({ step: "plugin-auth" });
   });
 
-  it("removes the current highlight and persistence when cancelled", async () => {
+  it("removes the current highlight and keeps cancellation local to the tab", async () => {
     stored("security");
     document.body.innerHTML = '<button id="security">Security and login</button>';
     makeGuide();
@@ -108,7 +203,7 @@ describe("opt-in setup guide", () => {
 
     shadow.querySelector<HTMLButtonElement>('[data-guide-action="cancel"]')?.click();
     await settle();
-    expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ active: false });
+    expect(sessionState()).toMatchObject({ active: false });
     expect(shadow.querySelector(".cfpt-guide-ring")?.classList.contains("cfpt-guide-hidden")).toBe(
       true,
     );

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -113,6 +113,28 @@ describe("run state", () => {
     expect(await storage.loadRun("c1")).toEqual(state);
   });
 
+  it("keeps simultaneous conversation state independent", async () => {
+    const first = {
+      ...newRunState("conversation-a", 1),
+      idea: "first project",
+      autoContinueEnabled: false,
+    };
+    const second = {
+      ...newRunState("conversation-b", 2),
+      idea: "second project",
+      queuedUserText: "second follow-up",
+    };
+
+    await storage.saveRun(first);
+    await storage.saveRun(second);
+
+    expect(await storage.loadRun("conversation-a")).toEqual(first);
+    expect(await storage.loadRun("conversation-b")).toEqual(second);
+    expect(stores.local[storage.runKey("conversation-a")]).not.toEqual(
+      stores.local[storage.runKey("conversation-b")],
+    );
+  });
+
   it("returns null for unknown conversations", async () => {
     expect(await storage.loadRun("nope")).toBeNull();
   });
@@ -138,6 +160,13 @@ describe("tab lock", () => {
   it("grants the lock to the first tab and refuses a live second tab", async () => {
     expect(await storage.acquireTabLock("c1", "tab-a")).toBe(true);
     expect(await storage.acquireTabLock("c1", "tab-b")).toBe(false);
+  });
+
+  it("allows different tabs to drive different conversations simultaneously", async () => {
+    expect(await storage.acquireTabLock("conversation-a", "tab-a")).toBe(true);
+    expect(await storage.acquireTabLock("conversation-b", "tab-b")).toBe(true);
+    expect(await storage.heartbeatTabLock("conversation-a", "tab-a")).toBe(true);
+    expect(await storage.heartbeatTabLock("conversation-b", "tab-b")).toBe(true);
   });
 
   it("is reentrant for the same nonce", async () => {

--- a/tests/stream-watch.test.ts
+++ b/tests/stream-watch.test.ts
@@ -118,7 +118,7 @@ describe("StreamWatcher", () => {
     expect(onComplete).not.toHaveBeenCalled();
   });
 
-  it("reports a stuck armed reply even when the stop button never appears", async () => {
+  it("does not age an expected reply into a false generation timeout before output starts", async () => {
     const onStuck = vi.fn();
     watcher = new StreamWatcher(
       { onStart: vi.fn(), onComplete: vi.fn(), onStuck },
@@ -127,8 +127,25 @@ describe("StreamWatcher", () => {
     watcher.start();
     watcher.expectReply();
 
-    await advance(1_600);
+    await advance(4_000);
 
+    expect(onStuck).not.toHaveBeenCalled();
+  });
+
+  it("starts the stuck timer when a reply is actually observed", async () => {
+    const onStart = vi.fn();
+    const onStuck = vi.fn();
+    watcher = new StreamWatcher(
+      { onStart, onComplete: vi.fn(), onStuck },
+      { ...SETTINGS, maxStreamMinutes: 0.001 },
+    );
+    watcher.start();
+    watcher.expectReply();
+    main().appendChild(assistant("new", "Still working without a final marker"));
+
+    await advance(2_400);
+
+    expect(onStart).toHaveBeenCalledTimes(1);
     expect(onStuck).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Result
Make Chat FreePT safe to use across simultaneous ChatGPT conversations and make the GitHub setup walkthrough robust to off-screen controls and already-completed steps.

## Implementation
- Preserve run/Auto-continue/queue state under the existing per-conversation storage keys and keep ownership locks per conversation.
- Stop writing a synthetic `USER_PAUSE` when a tab navigates to another conversation; detach the old controller/watchers before releasing ownership so old DOM/timers cannot describe the new conversation.
- Keep the single-driver lock only for duplicate tabs of the same conversation; different conversations retain independent lock keys and can run in parallel.
- Move setup-guide progress from extension-wide local storage to tab-scoped `sessionStorage`, preserving the guide across Settings → Plugins → chat navigation without leaking it into other tabs.
- Target the live semantic Developer mode switch via `role=switch` + `aria-label=Developer mode`, and scroll the settings modal's actual scroll region before positioning the highlight.
- Inspect live setup state and skip Developer mode when already enabled, already-filled app fields, OAuth/risk selections, and exact existing `GitHub MCP` developer-app results.
- Use the current Plugins UI's `#plugin-search` / `Search plugins` field and `Create app` control; never mistake the public `GitHub` result for the custom `GitHub MCP` app.
- Start the stream-stuck clock only after ChatGPT output is actually observed, and ignore watcher start/stuck callbacks when the current run is not in an active reply state.
- Preserve the stale extension-context terminal shutdown behavior from #54/#55.

## Verification
- Added setup-guide coverage for tab-local persistence, off-screen settings scrolling, already-enabled Developer mode, existing GitHub MCP reuse, and exact MCP URL entry.
- Added selector coverage matching the supplied live Settings/Plugins DOM, including separation of public GitHub from custom GitHub MCP.
- Added storage/lock coverage proving simultaneous different-conversation isolation.
- Updated stream-watch coverage to prove waiting time cannot become a false generation timeout and that the timeout begins on observed output.
- Hosted PR CI is the merge gate; the exact CI artifact will be preserved for live multi-tab browser validation before any production promotion.

## Risk
Medium. This changes content-script lifecycle behavior during ChatGPT SPA navigation and setup-guide persistence/targeting, but adds no extension permissions, host permissions, runtime dependencies, private ChatGPT APIs, or GitHub credentials. Duplicate tabs of the same conversation intentionally remain single-driver to prevent double sends.

## Remaining work
Run and satisfy all hosted PR checks, inspect any failures without weakening gates, preserve the exact installable PR artifact, then live-test simultaneous conversations plus the Settings/Plugins walkthrough before release.

Refs #58
Refs #11