### PR TITLE
Apply exact Prettier output to state isolation walkthrough

### DIFF
--- a/.github/workflows/prettier-state-walkthrough-diagnostic.yml
+++ b/.github/workflows/prettier-state-walkthrough-diagnostic.yml
@@ -1,0 +1,34 @@
+name: Prettier state walkthrough diagnostic
+
+on:
+  pull_request:
+    branches:
+      - work/58-isolate-state-walkthrough
+
+permissions:
+  contents: write
+
+jobs:
+  apply-format:
+    name: Apply exact Prettier output
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      - name: Install locked Node toolchain
+        run: npm ci --no-audit --no-fund
+      - name: Apply exact Prettier output to feature branch
+        run: |
+          git checkout -B work/58-isolate-state-walkthrough origin/work/58-isolate-state-walkthrough
+          npx prettier --write src/content/ui/setup-guide.ts tests/selectors.test.ts
+          if git diff --quiet -- src/content/ui/setup-guide.ts tests/selectors.test.ts; then
+            echo "State-isolation files are already formatted."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/content/ui/setup-guide.ts tests/selectors.test.ts
+          git commit -m "style: apply exact Prettier output"
+          git push origin HEAD:work/58-isolate-state-walkthrough


### PR DESCRIPTION
## Result
Apply exact locked Prettier output to the two PR #59 files that fail format checking.

## Implementation
- Temporary diagnostic workflow runs the repository's locked `npm ci` toolchain.
- Runs Prettier only on `src/content/ui/setup-guide.ts` and `tests/selectors.test.ts`.
- Pushes the exact formatter result back to `work/58-isolate-state-walkthrough`.

## Verification
PR #59 deterministic run 32924248738 already passes complexity/quality; only these two paths are reported by `npm run format:check`.

## Risk
Low. Formatting only. This diagnostic workflow will not be merged into the feature branch or `dev`.

## Remaining work
Confirm the workflow pushes exact formatter output, close this diagnostic PR unmerged, close #60, then re-run PR #59 CI.

Refs #60
Refs #58