### PR TITLE
Harden composer takeover and automate custom GitHub MCP setup

### DIFF
--- a/src/common/prompts.ts
+++ b/src/common/prompts.ts
@@ -42,11 +42,16 @@ or rejected by authorization, STOP and report the exact missing capability class
 tell me to configure GitHub's official remote MCP in ChatGPT:
 
 1. Settings → Security and login → Developer mode: turn it on.
-2. Open https://chatgpt.com/plugins, select +, and create a developer-mode app for
-   https://api.githubcopilot.com/mcp/ using OAuth.
-3. In this conversation, open the Plus menu, choose Developer mode, and select that GitHub
-   app for the conversation.
-4. Authorize repository and workflow write access needed for this project.
+2. Open https://chatgpt.com/plugins, select + / Create app, and create a custom
+   developer-mode app named GitHub MCP using Server URL
+   https://api.githubcopilot.com/mcp/ and OAuth. Complete ChatGPT's explicit risk
+   acknowledgement and the GitHub authorization yourself.
+3. Return to this conversation and resume. Do not require a separate composer attachment
+   or a Developer mode → GitHub MCP menu item when the current ChatGPT UI does not expose
+   one; instead, run this capability preflight again and trust the tools actually available.
+4. If the remote MCP still does not expose the required repository/workflow write
+   capabilities after OAuth, report the exact missing capability classes rather than
+   substituting the ordinary GitHub plugin or pretending setup succeeded.
 
 Do not ask me to run shell commands or click GitHub controls. End with NEEDS_INPUT so I can
 finish only the ChatGPT/MCP setup and then resume.`;

--- a/src/common/prompts.ts
+++ b/src/common/prompts.ts
@@ -41,20 +41,27 @@ export const DEVELOPER_MODE_SETUP_BLOCK = `If a required capability is missing, 
 or rejected by authorization, STOP and report the exact missing capability classes. Then
 tell me to configure GitHub's official remote MCP in ChatGPT:
 
-1. Settings → Security and login → Developer mode: turn it on.
-2. Open https://chatgpt.com/plugins, select + / Create app, and create a custom
-   developer-mode app named GitHub MCP using Server URL
-   https://api.githubcopilot.com/mcp/ and OAuth. Complete ChatGPT's explicit risk
-   acknowledgement and the GitHub authorization yourself.
-3. Return to this conversation and resume. Do not require a separate composer attachment
+1. Start Chat FreePT's GitHub setup and choose Follow along. The extension should open
+   Settings → Security and login, enable Developer mode when the host permits it, and open
+   Plugins automatically. If ChatGPT presents an additional security confirmation, I must
+   approve it myself.
+2. In https://chatgpt.com/plugins, create or reuse the dedicated custom app named
+   Chat FreePT GitHub MCP. Use Server URL
+   https://api.githubcopilot.com/mcp/x/all and OAuth. GitHub documents /x/all as the remote
+   endpoint exposing all available MCP toolsets, which is appropriate for this release-engineering
+   workflow because repository, Issue, label, pull-request, Git and Actions capabilities are required.
+3. The extension may fill the safe fields and press Create after I explicitly check
+   ChatGPT's custom-MCP risk acknowledgement. It must never check that acknowledgement for me
+   or bypass GitHub OAuth. Complete the GitHub authorization myself.
+4. Return to this conversation and resume. Do not require a separate composer attachment
    or a Developer mode → GitHub MCP menu item when the current ChatGPT UI does not expose
    one; instead, run this capability preflight again and trust the tools actually available.
-4. If the remote MCP still does not expose the required repository/workflow write
+5. If the remote MCP still does not expose the required repository/workflow write
    capabilities after OAuth, report the exact missing capability classes rather than
    substituting the ordinary GitHub plugin or pretending setup succeeded.
 
 Do not ask me to run shell commands or click GitHub controls. End with NEEDS_INPUT so I can
-finish only the ChatGPT/MCP setup and then resume.`;
+finish only the explicit ChatGPT/GitHub consent step and then resume.`;
 
 const CORE_MCP_REQUIREMENTS = `Core capabilities required in both modes (tool names may
 differ; match capabilities semantically): read repositories/files/trees; create branches;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -13,15 +13,18 @@ import type { RunState, Settings } from "../common/types";
 import type { ContentRequest } from "../common/types";
 import { createExtensionContextGuard } from "./extension-context";
 import { conversationIdFromUrl, watchNavigation } from "./navigation";
+import { chatGptPageMode, type ChatGptPageMode } from "./page-mode";
 import { RunController } from "./run-controller";
 import { require_ } from "./selectors";
 import { Panel } from "./ui/panel";
+import { SetupGuide } from "./ui/setup-guide";
 
 const HEARTBEAT_MS = 5000;
 const TAKEOVER_RETRY_MS = 5000;
 const tabNonce = crypto.randomUUID();
 
 let panel: Panel | null = null;
+let standaloneGuide: SetupGuide | null = null;
 let controller: RunController | null = null;
 let currentConvId = "";
 let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
@@ -53,6 +56,8 @@ function shutdownInvalidatedContext(): void {
   controller = null;
   panel?.dispose();
   panel = null;
+  standaloneGuide?.dispose();
+  standaloneGuide = null;
 }
 
 function reportAsyncFailure(message: string, error: unknown): void {
@@ -156,7 +161,7 @@ async function tryTakeover(conversationId: string): Promise<void> {
 function loseOwnership(conversationId: string): void {
   if (contextGuard.invalidated || !controller || conversationId !== currentConvId) return;
   const state = controller.state;
-  log.warn("conversation ownership moved to another tab; becoming passive");
+  log.info("conversation ownership moved to another tab; becoming passive");
   enterPassive(state);
 }
 
@@ -173,7 +178,7 @@ async function initConversation(convId: string): Promise<void> {
   const locked = await acquireTabLock(convId, tabNonce);
   if (contextGuard.invalidated) return;
   if (!locked) {
-    log.warn("another tab is driving this conversation; staying passive");
+    log.info("another tab is driving this conversation; staying passive");
     enterPassive(state);
     return;
   }
@@ -181,8 +186,55 @@ async function initConversation(convId: string): Promise<void> {
   startController(state, settings);
 }
 
-async function onNavigate(href: string): Promise<void> {
+function ensureStandaloneGuide(mode: ChatGptPageMode): void {
+  if (mode !== "plugins" || panel || standaloneGuide || contextGuard.invalidated) return;
+  standaloneGuide = new SetupGuide();
+}
+
+function clearStandaloneGuide(): void {
+  standaloneGuide?.dispose();
+  standaloneGuide = null;
+}
+
+async function leaveConversationForUtilityPage(mode: ChatGptPageMode): Promise<void> {
+  stopTakeoverRetry();
+  controller?.dispose();
+  controller = null;
+  stopHeartbeat();
+  const previous = currentConvId;
+  currentConvId = "";
+  await releaseOwnedLock(previous);
   if (contextGuard.invalidated) return;
+  ensureStandaloneGuide(mode);
+  log.debug(`Chat FreePT idle on expected non-composer route (${mode})`);
+}
+
+async function activateComposerPage(): Promise<void> {
+  if (contextGuard.invalidated || panel) return;
+  clearStandaloneGuide();
+  try {
+    await require_("composer", 45000, 500);
+  } catch {
+    const mode = chatGptPageMode(location.href);
+    if (mode !== "composer") {
+      ensureStandaloneGuide(mode);
+      log.debug(`Chat FreePT idle on expected non-composer route (${mode})`);
+      return;
+    }
+    log.warn("composer never appeared; Chat FreePT idle (logged out or layout change?)");
+    return;
+  }
+  if (contextGuard.invalidated || chatGptPageMode(location.href) !== "composer" || panel) return;
+
+  panel = new Panel({
+    onEvent: (event) => controller?.dispatch(event),
+    getHandoffPrompt: () => (controller ? buildHandoffPrompt(controller.state) : ""),
+  });
+  await initConversation(conversationKeyFromLocation());
+  if (!contextGuard.invalidated) log.info("Chat FreePT ready");
+}
+
+async function onComposerNavigate(href: string): Promise<void> {
   const urlConv = conversationIdFromUrl(href);
 
   if (urlConv && currentConvId.startsWith("pending:") && controller) {
@@ -207,7 +259,7 @@ async function onNavigate(href: string): Promise<void> {
       if (contextGuard.invalidated) return;
       currentConvId = urlConv;
       const state = (await loadRun(urlConv)) ?? newRunState(urlConv, Date.now());
-      log.warn("another tab owns the permanent conversation id; staying passive");
+      log.info("another tab owns the permanent conversation id; staying passive");
       enterPassive(state);
       return;
     }
@@ -232,20 +284,21 @@ async function onNavigate(href: string): Promise<void> {
   await initConversation(urlConv ?? `pending:${crypto.randomUUID()}`);
 }
 
-async function boot(): Promise<void> {
-  try {
-    await require_("composer", 45000, 500);
-  } catch {
-    log.warn("composer never appeared; Chat FreePT idle (logged out or layout change?)");
+async function onNavigate(href: string): Promise<void> {
+  if (contextGuard.invalidated) return;
+  const mode = chatGptPageMode(href);
+  if (mode !== "composer") {
+    await leaveConversationForUtilityPage(mode);
     return;
   }
-  if (contextGuard.invalidated) return;
+  if (!panel) {
+    await activateComposerPage();
+    return;
+  }
+  await onComposerNavigate(href);
+}
 
-  panel = new Panel({
-    onEvent: (event) => controller?.dispatch(event),
-    getHandoffPrompt: () => (controller ? buildHandoffPrompt(controller.state) : ""),
-  });
-
+function installLifecycleListeners(): void {
   chrome.runtime.onMessage.addListener((message: ContentRequest) => {
     if (message.type === "toggle-panel") panel?.toggle();
   });
@@ -261,8 +314,17 @@ async function boot(): Promise<void> {
   stopNavigation = watchNavigation((href) => {
     void onNavigate(href).catch((error) => reportAsyncFailure("navigation handling failed", error));
   });
-  await initConversation(conversationKeyFromLocation());
-  if (!contextGuard.invalidated) log.info("Chat FreePT ready");
+}
+
+async function boot(): Promise<void> {
+  installLifecycleListeners();
+  const mode = chatGptPageMode(location.href);
+  if (mode !== "composer") {
+    ensureStandaloneGuide(mode);
+    log.debug(`Chat FreePT idle on expected non-composer route (${mode})`);
+    return;
+  }
+  await activateComposerPage();
 }
 
 void boot().catch((error) => reportAsyncFailure("Chat FreePT boot failed", error));

--- a/src/content/page-mode.ts
+++ b/src/content/page-mode.ts
@@ -1,0 +1,22 @@
+export type ChatGptPageMode = "composer" | "plugins" | "utility";
+
+const UTILITY_PATH_PREFIXES = ["/library", "/scheduled"];
+
+/**
+ * ChatGPT has first-party pages where the conversation composer is intentionally absent.
+ * Treating those pages as selector failures creates false warnings and blocks the setup guide.
+ */
+export function chatGptPageMode(href: string): ChatGptPageMode {
+  let url: URL;
+  try {
+    url = new URL(href, "https://chatgpt.com");
+  } catch {
+    return "composer";
+  }
+
+  if (url.pathname === "/plugins" || url.pathname.startsWith("/plugins/")) return "plugins";
+  if (UTILITY_PATH_PREFIXES.some((prefix) => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`))) {
+    return "utility";
+  }
+  return "composer";
+}

--- a/src/content/page-mode.ts
+++ b/src/content/page-mode.ts
@@ -15,7 +15,11 @@ export function chatGptPageMode(href: string): ChatGptPageMode {
   }
 
   if (url.pathname === "/plugins" || url.pathname.startsWith("/plugins/")) return "plugins";
-  if (UTILITY_PATH_PREFIXES.some((prefix) => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`))) {
+  if (
+    UTILITY_PATH_PREFIXES.some(
+      (prefix) => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`),
+    )
+  ) {
     return "utility";
   }
   return "composer";

--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -27,6 +27,7 @@ export type GuideTargetId =
   | "pluginAddButton"
   | "githubMcpPluginResult"
   | "pluginNameInput"
+  | "pluginServerUrlOption"
   | "pluginServerInput"
   | "pluginAuthControl"
   | "pluginRiskCheckbox"
@@ -240,15 +241,14 @@ const GUIDE_RESOLVERS: Record<GuideTargetId, () => HTMLElement | null> = {
   pluginSearchInput,
   pluginAddButton,
   githubMcpPluginResult,
-  pluginNameInput: () => fieldNearLabel(/^(Name|Plugin name)$/i, "input"),
-  pluginServerInput: () =>
-    fieldNearLabel(/(Server URL|Remote MCP|MCP server URL)/i, 'input[type="url"], input'),
-  pluginAuthControl: () => fieldNearLabel(/Authentication/i, 'select, [role="combobox"], button'),
-  pluginRiskCheckbox: () =>
-    controlNearText(/I understand.*continue/i, 'input[type="checkbox"], [role="checkbox"]'),
-  pluginCreateButton: () => clickableText(/^Create$/i),
+  pluginNameInput,
+  pluginServerUrlOption,
+  pluginServerInput,
+  pluginAuthControl,
+  pluginRiskCheckbox,
+  pluginCreateButton,
   conversationDeveloperMode: () => clickableText(/^Developer mode$/i),
-  conversationGitHubMcp: () => clickableText(/^GitHub MCP$/i) ?? clickableText(/^GitHub$/i),
+  conversationGitHubMcp: () => clickableText(/^GitHub MCP$/i),
 };
 
 export function queryGuideTarget(id: GuideTargetId): HTMLElement | null {
@@ -334,6 +334,46 @@ function githubMcpPluginResult(): HTMLElement | null {
   );
   if (labeled) return labeled;
   return clickableText(/^GitHub MCP$/i);
+}
+
+function pluginNameInput(): HTMLElement | null {
+  return (
+    document.getElementById("custom-connector-name") ??
+    fieldNearLabel(/^(Name|Plugin name)$/i, "input")
+  ) as HTMLElement | null;
+}
+
+function pluginServerUrlOption(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    '[role="radio"][aria-label="Server URL"], button[aria-label="Server URL"]',
+  );
+}
+
+function pluginServerInput(): HTMLElement | null {
+  return (
+    document.getElementById("custom-connector-url") ??
+    fieldNearLabel(/(Server URL|Remote MCP|MCP server URL)/i, 'input[type="url"], input')
+  ) as HTMLElement | null;
+}
+
+function pluginAuthControl(): HTMLElement | null {
+  return (
+    document.getElementById("custom-connector-auth") ??
+    fieldNearLabel(/Authentication/i, 'select, [role="combobox"], button')
+  ) as HTMLElement | null;
+}
+
+function pluginRiskCheckbox(): HTMLElement | null {
+  return (
+    document.getElementById("trust-checkbox") ??
+    controlNearText(/I understand.*continue/i, 'input[type="checkbox"], [role="checkbox"]')
+  ) as HTMLElement | null;
+}
+
+function pluginCreateButton(): HTMLElement | null {
+  const modal = document.getElementById("modal-create-custom-connector");
+  const submit = modal?.querySelector<HTMLElement>('button[type="submit"]');
+  return submit ?? clickableText(/^Create$/i);
 }
 
 function clickableText(pattern: RegExp): HTMLElement | null {

--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -337,10 +337,8 @@ function githubMcpPluginResult(): HTMLElement | null {
 }
 
 function pluginNameInput(): HTMLElement | null {
-  return (
-    document.getElementById("custom-connector-name") ??
-    fieldNearLabel(/^(Name|Plugin name)$/i, "input")
-  ) as HTMLElement | null;
+  return (document.getElementById("custom-connector-name") ??
+    fieldNearLabel(/^(Name|Plugin name)$/i, "input")) as HTMLElement | null;
 }
 
 function pluginServerUrlOption(): HTMLElement | null {
@@ -350,24 +348,24 @@ function pluginServerUrlOption(): HTMLElement | null {
 }
 
 function pluginServerInput(): HTMLElement | null {
-  return (
-    document.getElementById("custom-connector-url") ??
-    fieldNearLabel(/(Server URL|Remote MCP|MCP server URL)/i, 'input[type="url"], input')
-  ) as HTMLElement | null;
+  return (document.getElementById("custom-connector-url") ??
+    fieldNearLabel(
+      /(Server URL|Remote MCP|MCP server URL)/i,
+      'input[type="url"], input',
+    )) as HTMLElement | null;
 }
 
 function pluginAuthControl(): HTMLElement | null {
-  return (
-    document.getElementById("custom-connector-auth") ??
-    fieldNearLabel(/Authentication/i, 'select, [role="combobox"], button')
-  ) as HTMLElement | null;
+  return (document.getElementById("custom-connector-auth") ??
+    fieldNearLabel(/Authentication/i, 'select, [role="combobox"], button')) as HTMLElement | null;
 }
 
 function pluginRiskCheckbox(): HTMLElement | null {
-  return (
-    document.getElementById("trust-checkbox") ??
-    controlNearText(/I understand.*continue/i, 'input[type="checkbox"], [role="checkbox"]')
-  ) as HTMLElement | null;
+  return (document.getElementById("trust-checkbox") ??
+    controlNearText(
+      /I understand.*continue/i,
+      'input[type="checkbox"], [role="checkbox"]',
+    )) as HTMLElement | null;
 }
 
 function pluginCreateButton(): HTMLElement | null {

--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -30,6 +30,7 @@ export type GuideTargetId =
   | "pluginServerUrlOption"
   | "pluginServerInput"
   | "pluginAuthControl"
+  | "pluginOauthOption"
   | "pluginRiskCheckbox"
   | "pluginCreateButton"
   | "conversationDeveloperMode"
@@ -245,10 +246,11 @@ const GUIDE_RESOLVERS: Record<GuideTargetId, () => HTMLElement | null> = {
   pluginServerUrlOption,
   pluginServerInput,
   pluginAuthControl,
+  pluginOauthOption,
   pluginRiskCheckbox,
   pluginCreateButton,
   conversationDeveloperMode: () => clickableText(/^Developer mode$/i),
-  conversationGitHubMcp: () => clickableText(/^GitHub MCP$/i),
+  conversationGitHubMcp: () => clickableText(/^(Chat FreePT GitHub MCP|GitHub MCP)$/i),
 };
 
 export function queryGuideTarget(id: GuideTargetId): HTMLElement | null {
@@ -330,10 +332,10 @@ function pluginAddButton(): HTMLElement | null {
 
 function githubMcpPluginResult(): HTMLElement | null {
   const labeled = document.querySelector<HTMLElement>(
-    'a[aria-label="Open GitHub MCP"], button[aria-label="Open GitHub MCP"]',
+    'a[aria-label="Open Chat FreePT GitHub MCP"], button[aria-label="Open Chat FreePT GitHub MCP"]',
   );
   if (labeled) return labeled;
-  return clickableText(/^GitHub MCP$/i);
+  return clickableText(/^Chat FreePT GitHub MCP$/i);
 }
 
 function pluginNameInput(): HTMLElement | null {
@@ -358,6 +360,15 @@ function pluginServerInput(): HTMLElement | null {
 function pluginAuthControl(): HTMLElement | null {
   return (document.getElementById("custom-connector-auth") ??
     fieldNearLabel(/Authentication/i, 'select, [role="combobox"], button')) as HTMLElement | null;
+}
+
+function pluginOauthOption(): HTMLElement | null {
+  const candidates = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"], [role="menuitem"], [role="menuitemradio"], button'),
+  );
+  const exact = candidates.filter((element) => /^OAuth$/i.test((element.textContent ?? "").trim()));
+  exact.sort((a, b) => a.children.length - b.children.length);
+  return exact[0] ?? null;
 }
 
 function pluginRiskCheckbox(): HTMLElement | null {

--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -359,12 +359,17 @@ function pluginServerInput(): HTMLElement | null {
 
 function pluginAuthControl(): HTMLElement | null {
   return (document.getElementById("custom-connector-auth") ??
+    document.querySelector<HTMLElement>(
+      'select[aria-label*="Authentication" i], [role="combobox"][aria-label*="Authentication" i], button[aria-label*="Authentication" i]',
+    ) ??
     fieldNearLabel(/Authentication/i, 'select, [role="combobox"], button')) as HTMLElement | null;
 }
 
 function pluginOauthOption(): HTMLElement | null {
   const candidates = Array.from(
-    document.querySelectorAll<HTMLElement>('[role="option"], [role="menuitem"], [role="menuitemradio"], button'),
+    document.querySelectorAll<HTMLElement>(
+      '[role="option"], [role="menuitem"], [role="menuitemradio"], button',
+    ),
   );
   const exact = candidates.filter((element) => /^OAuth$/i.test((element.textContent ?? "").trim()));
   exact.sort((a, b) => a.children.length - b.children.length);

--- a/src/content/ui/panel.ts
+++ b/src/content/ui/panel.ts
@@ -21,7 +21,7 @@ interface OnboardingState {
 interface NativeSurfaceSnapshot {
   element: HTMLElement;
   pointerEvents: string;
-  ariaHidden: string | null;
+  inert: boolean;
 }
 
 const ONBOARDING_KEY = "cfpt:onboarding:v1";
@@ -192,7 +192,12 @@ export class Panel {
     button.setAttribute("aria-label", "Open Chat FreePT");
     button.setAttribute("aria-expanded", "false");
     button.innerHTML = airplaneSvg();
-    button.addEventListener("click", () => this.onLauncherClick());
+    button.addEventListener("pointerdown", (event) => event.stopPropagation());
+    button.addEventListener("mousedown", (event) => event.stopPropagation());
+    button.addEventListener("click", (event) => {
+      event.stopPropagation();
+      this.onLauncherClick();
+    });
     shadow.appendChild(button);
     return { host, shadow, button };
   }
@@ -377,22 +382,29 @@ export class Panel {
     if (!(surface instanceof HTMLElement)) return;
     if (this.nativeSurface?.element === surface) return;
     this.restoreNativeTakeover();
+    this.moveFocusOutsideNativeSurface(surface);
     this.nativeSurface = {
       element: surface,
       pointerEvents: surface.style.pointerEvents,
-      ariaHidden: surface.getAttribute("aria-hidden"),
+      inert: surface.inert,
     };
     surface.style.pointerEvents = "none";
-    surface.setAttribute("aria-hidden", "true");
+    surface.inert = true;
     surface.dataset["cfptTakeover"] = "true";
+  }
+
+  private moveFocusOutsideNativeSurface(surface: HTMLElement): void {
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement) || !surface.contains(active)) return;
+    this.panelEl.querySelector<HTMLElement>(".cfpt-panel-close")?.focus({ preventScroll: true });
+    if (surface.contains(document.activeElement)) active.blur();
   }
 
   private restoreNativeTakeover(): void {
     const snapshot = this.nativeSurface;
     if (!snapshot) return;
     snapshot.element.style.pointerEvents = snapshot.pointerEvents;
-    if (snapshot.ariaHidden === null) snapshot.element.removeAttribute("aria-hidden");
-    else snapshot.element.setAttribute("aria-hidden", snapshot.ariaHidden);
+    snapshot.element.inert = snapshot.inert;
     delete snapshot.element.dataset["cfptTakeover"];
     this.nativeSurface = null;
   }
@@ -815,7 +827,7 @@ function paidSetupHtml(): string {
       <div class="cfpt-plan-badge">Paid plan · full GitHub automation</div>
       <h2 id="cfpt-setup-title">Connect GitHub with a follow-along guide</h2>
       <p class="cfpt-setup-lead">For full autonomous repository work, Chat FreePT needs ChatGPT's Developer mode and a custom GitHub MCP/plugin with the write permissions you approve. ChatGPT marks Developer mode as Elevated Risk because unverified connectors can modify data.</p>
-      <p class="cfpt-setup-lead">The guide opens Settings for you and highlights one live ChatGPT control at a time: Security and login → Developer mode → Plugins → + → GitHub MCP URL → OAuth → Create → add GitHub MCP to this chat.</p>
+      <p class="cfpt-setup-lead">The guide opens Settings, enables Developer mode, then takes you to Plugins. It can open the custom app form and fill the GitHub MCP name, remote server URL, and OAuth choice automatically. You still approve ChatGPT's risk warning and GitHub OAuth yourself; afterward the guide returns here and Chat FreePT verifies the actual GitHub capabilities.</p>
       <div class="cfpt-setup-actions">
         <button class="cfpt-btn" type="button" data-action="free-setup">Using ChatGPT Free?</button>
         <button class="cfpt-btn" type="button" data-action="setup-done">I'll set it up myself</button>

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -13,9 +13,6 @@ export type SetupGuideStep =
   | "plugin-risk"
   | "plugin-create"
   | "oauth"
-  | "chat-plus"
-  | "developer-menu"
-  | "github-app"
   | "done";
 
 interface StoredGuide {
@@ -30,10 +27,10 @@ interface GuideCopy {
   actions: string;
 }
 
-const SESSION_KEY = "cfpt:setup-guide:v2";
+const SESSION_KEY = "cfpt:setup-guide:v3";
 const MCP_URL = "https://api.githubcopilot.com/mcp/";
 const PLUGINS_URL = "https://chatgpt.com/plugins";
-const SEARCH_VALUE = "GitHub MCP";
+const APP_NAME = "GitHub MCP";
 const SCROLL_RETRY_MS = 150;
 
 const GUIDE_STEPS = new Set<SetupGuideStep>([
@@ -49,9 +46,6 @@ const GUIDE_STEPS = new Set<SetupGuideStep>([
   "plugin-risk",
   "plugin-create",
   "oauth",
-  "chat-plus",
-  "developer-menu",
-  "github-app",
   "done",
 ]);
 
@@ -82,7 +76,7 @@ const GUIDE_CSS = `
 .cfpt-guide-card {
   position: fixed;
   pointer-events: auto;
-  width: min(340px, calc(100vw - 24px));
+  width: min(350px, calc(100vw - 24px));
   padding: 14px;
   border: 1px solid var(--border);
   border-radius: 16px;
@@ -137,22 +131,7 @@ const TARGETS: Partial<Record<SetupGuideStep, GuideTargetId>> = {
   "plugin-auth": "pluginAuthControl",
   "plugin-risk": "pluginRiskCheckbox",
   "plugin-create": "pluginCreateButton",
-  "chat-plus": "composerPlusButton",
-  "developer-menu": "conversationDeveloperMode",
-  "github-app": "conversationGitHubMcp",
 };
-
-const EARLY_COPY_STEPS = new Set<SetupGuideStep>([
-  "security",
-  "developer",
-  "developer-toggle",
-  "plugins",
-  "plugin-search",
-  "plugin-add",
-  "plugin-name",
-  "plugin-server",
-  "plugin-auth",
-]);
 
 export class SetupGuide {
   private readonly host: HTMLDivElement;
@@ -165,6 +144,7 @@ export class SetupGuide {
   private returnUrl = "https://chatgpt.com/";
   private lastScrolledStep: SetupGuideStep | null = null;
   private lastScrollAttemptAt = 0;
+  private autoActionStep: SetupGuideStep | null = null;
   private disposed = false;
 
   constructor() {
@@ -199,7 +179,7 @@ export class SetupGuide {
     this.active = true;
     this.step = "security";
     this.returnUrl = chatReturnUrl();
-    this.resetScrollTracking();
+    this.resetStepTracking();
     this.persist();
     this.render();
     openSettings();
@@ -259,11 +239,6 @@ export class SetupGuide {
   }
 
   private currentTarget(): HTMLElement | null {
-    if (this.step === "developer-menu") {
-      return (
-        queryGuideTarget("conversationDeveloperMode") ?? queryGuideTarget("conversationGitHubMcp")
-      );
-    }
     const id = TARGETS[this.step];
     return id ? queryGuideTarget(id) : null;
   }
@@ -305,31 +280,18 @@ export class SetupGuide {
   }
 
   private advancePluginStep(): boolean {
-    if (this.existingPluginCompletesCreation()) return true;
-    return this.advancePluginFormStep();
-  }
-
-  private existingPluginCompletesCreation(): boolean {
-    if (this.step !== "plugin-search" && this.step !== "plugin-add") return false;
-    if (!queryGuideTarget("githubMcpPluginResult")) return false;
-    this.returnToChat();
-    return true;
-  }
-
-  private advancePluginFormStep(): boolean {
+    if (this.existingPluginCompletesSetup()) return true;
     switch (this.step) {
       case "plugin-search":
-        return this.advanceWhenFieldMatches("pluginSearchInput", SEARCH_VALUE, "plugin-add");
+        return this.autoSearchForPlugin();
+      case "plugin-add":
+        return this.autoOpenCreateForm();
       case "plugin-name":
-        return this.advanceWhenFieldMatches("pluginNameInput", SEARCH_VALUE, "plugin-server");
+        return this.autoFillName();
       case "plugin-server":
-        return this.advanceWhenFieldMatches("pluginServerInput", MCP_URL, "plugin-auth", true);
-      case "plugin-auth": {
-        const auth = queryGuideTarget("pluginAuthControl");
-        if (!controlValue(auth).includes("oauth")) return false;
-        void this.setStep("plugin-risk");
-        return true;
-      }
+        return this.autoFillServer();
+      case "plugin-auth":
+        return this.autoSelectOauth();
       case "plugin-risk": {
         const risk = queryGuideTarget("pluginRiskCheckbox");
         if (!risk || !isControlEnabled(risk)) return false;
@@ -341,20 +303,70 @@ export class SetupGuide {
     }
   }
 
-  private advanceWhenFieldMatches(
-    id: GuideTargetId,
-    expected: string,
-    next: SetupGuideStep,
-    ignoreTrailingSlash = false,
-  ): boolean {
-    let actual = fieldValue(queryGuideTarget(id)).trim();
-    let target = expected;
-    if (ignoreTrailingSlash) {
-      actual = actual.replace(/\/$/, "");
-      target = target.replace(/\/$/, "");
+  private existingPluginCompletesSetup(): boolean {
+    if (!new Set<SetupGuideStep>(["plugin-search", "plugin-add", "oauth"]).has(this.step)) {
+      return false;
     }
-    if (actual.toLowerCase() !== target.toLowerCase()) return false;
-    void this.setStep(next);
+    if (!queryGuideTarget("githubMcpPluginResult")) return false;
+    this.returnToChat();
+    return true;
+  }
+
+  private autoSearchForPlugin(): boolean {
+    const search = queryGuideTarget("pluginSearchInput");
+    if (!(search instanceof HTMLInputElement || search instanceof HTMLTextAreaElement)) return false;
+    if (fieldValue(search).trim().toLowerCase() !== APP_NAME.toLowerCase()) {
+      setNativeValue(search, APP_NAME);
+    }
+    return this.oncePerStep("plugin-search", () => {
+      setTimeout(() => void this.setStep("plugin-add"), 300);
+    });
+  }
+
+  private autoOpenCreateForm(): boolean {
+    const create = queryGuideTarget("pluginAddButton");
+    if (!create) return false;
+    return this.oncePerStep("plugin-add", () => {
+      create.click();
+      setTimeout(() => void this.setStep("plugin-name"), 100);
+    });
+  }
+
+  private autoFillName(): boolean {
+    const input = queryGuideTarget("pluginNameInput");
+    if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) return false;
+    if (fieldValue(input).trim() !== APP_NAME) setNativeValue(input, APP_NAME);
+    void this.setStep("plugin-server");
+    return true;
+  }
+
+  private autoFillServer(): boolean {
+    const option = queryGuideTarget("pluginServerUrlOption");
+    if (option && !isControlEnabled(option)) {
+      return this.oncePerStep("plugin-server", () => option.click());
+    }
+    const input = queryGuideTarget("pluginServerInput");
+    if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) return false;
+    if (!sameUrl(fieldValue(input), MCP_URL)) setNativeValue(input, MCP_URL);
+    void this.setStep("plugin-auth");
+    return true;
+  }
+
+  private autoSelectOauth(): boolean {
+    const auth = queryGuideTarget("pluginAuthControl");
+    if (!auth) return false;
+    if (auth instanceof HTMLSelectElement && auth.value.toUpperCase() !== "OAUTH") {
+      setNativeSelectValue(auth, "OAUTH");
+    }
+    if (!controlValue(auth).includes("oauth")) return false;
+    void this.setStep("plugin-risk");
+    return true;
+  }
+
+  private oncePerStep(step: SetupGuideStep, action: () => void): boolean {
+    if (this.autoActionStep === step) return true;
+    this.autoActionStep = step;
+    action();
     return true;
   }
 
@@ -387,7 +399,7 @@ export class SetupGuide {
     }
 
     const rect = target.getBoundingClientRect();
-    const width = Math.min(340, window.innerWidth - 24);
+    const width = Math.min(350, window.innerWidth - 24);
     const left = Math.min(Math.max(12, rect.left), Math.max(12, window.innerWidth - width - 12));
     const roomBelow = window.innerHeight - rect.bottom;
     const top = roomBelow > 210 ? rect.bottom + 12 : Math.max(12, rect.top - 190);
@@ -431,9 +443,6 @@ export class SetupGuide {
           if (isControlEnabled(target)) void this.setStep("plugins");
         }, 120);
         break;
-      case "plugin-add":
-        this.deferStep("plugin-name");
-        break;
       case "plugin-risk":
         setTimeout(() => {
           if (isControlEnabled(target)) void this.setStep("plugin-create");
@@ -441,16 +450,6 @@ export class SetupGuide {
         break;
       case "plugin-create":
         this.deferStep("oauth");
-        break;
-      case "chat-plus":
-        this.deferStep("developer-menu");
-        break;
-      case "developer-menu":
-        if (target === queryGuideTarget("conversationGitHubMcp")) this.deferStep("done");
-        else this.deferStep("github-app");
-        break;
-      case "github-app":
-        this.deferStep("done");
         break;
     }
   }
@@ -461,14 +460,15 @@ export class SetupGuide {
 
   private async setStep(step: SetupGuideStep): Promise<void> {
     this.step = step;
-    this.resetScrollTracking();
+    this.resetStepTracking();
     this.persist();
     this.render();
   }
 
-  private resetScrollTracking(): void {
+  private resetStepTracking(): void {
     this.lastScrolledStep = null;
     this.lastScrollAttemptAt = 0;
+    this.autoActionStep = null;
   }
 
   private onGuideClick(event: Event): void {
@@ -479,13 +479,6 @@ export class SetupGuide {
     if (action === "cancel") void this.cancel();
     else if (action === "developer-next") void this.setStep("developer-toggle");
     else if (action === "open-plugins") this.openPlugins();
-    else if (action === "search-plugin") this.searchForPlugin();
-    else if (action === "fill-name") {
-      this.fillField("pluginNameInput", SEARCH_VALUE, "plugin-server");
-    } else if (action === "fill-url") {
-      this.fillField("pluginServerInput", MCP_URL, "plugin-auth");
-    } else if (action === "auth-next") void this.setStep("plugin-risk");
-    else if (action === "risk-next") this.advanceRisk();
     else if (action === "return-chat") this.returnToChat();
     else if (action === "finish") void this.finish();
   }
@@ -494,27 +487,8 @@ export class SetupGuide {
     void this.setStep("plugin-search").then(() => navigate(PLUGINS_URL));
   }
 
-  private searchForPlugin(): void {
-    const search = queryGuideTarget("pluginSearchInput");
-    if (!(search instanceof HTMLInputElement || search instanceof HTMLTextAreaElement)) return;
-    setNativeValue(search, SEARCH_VALUE);
-    setTimeout(() => void this.setStep("plugin-add"), 250);
-  }
-
-  private fillField(id: GuideTargetId, value: string, next: SetupGuideStep): void {
-    const field = queryGuideTarget(id);
-    if (!(field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement)) return;
-    setNativeValue(field, value);
-    void this.setStep(next);
-  }
-
-  private advanceRisk(): void {
-    const checkbox = queryGuideTarget("pluginRiskCheckbox");
-    if (checkbox && isControlEnabled(checkbox)) void this.setStep("plugin-create");
-  }
-
   private returnToChat(): void {
-    void this.setStep("chat-plus").then(() => navigate(this.returnUrl));
+    void this.setStep("done").then(() => navigate(this.returnUrl));
   }
 
   private async finish(): Promise<void> {
@@ -537,16 +511,9 @@ export class SetupGuide {
 
 function guideCopy(step: SetupGuideStep, found: boolean): GuideCopy {
   const wait = found ? "" : " I’m waiting for this ChatGPT control to appear.";
-  return EARLY_COPY_STEPS.has(step) ? guideCopyEarly(step, wait) : guideCopyLate(step, wait);
-}
-
-function guideCopyEarly(step: SetupGuideStep, wait: string): GuideCopy {
   switch (step) {
     case "security":
-      return copy(
-        "1 · Security and login",
-        `Click the highlighted <b>Security and login</b> item.${wait}`,
-      );
+      return copy("1 · Security and login", `Click the highlighted <b>Security and login</b> item.${wait}`);
     case "developer":
       return copy(
         "2 · Developer mode",
@@ -556,87 +523,46 @@ function guideCopyEarly(step: SetupGuideStep, wait: string): GuideCopy {
     case "developer-toggle":
       return copy(
         "3 · Enable Developer mode",
-        `Turn on the highlighted <b>Developer mode</b> switch. If it is already on, the guide skips this step automatically.${wait}`,
+        `Turn on the highlighted <b>Developer mode</b> switch. If it is already on, I skip this step automatically.${wait}`,
       );
     case "plugins":
       return copy(
         "4 · Open Plugins",
-        "Developer mode is ready. Continue to ChatGPT Plugins; the guide checks for an existing GitHub MCP before asking you to create one.",
+        "Developer mode is ready. Open Plugins; from there I’ll check for an existing custom GitHub MCP and prepare the form automatically.",
         primary("open-plugins", "Open Plugins"),
       );
     case "plugin-search":
-      return copy(
-        "5 · Check for GitHub MCP",
-        `Search for <b>${SEARCH_VALUE}</b>. If your developer app already exists, the guide will reuse it.${wait}`,
-        primary("search-plugin", "Search GitHub MCP"),
-      );
+      return copy("5 · Checking for GitHub MCP", `I’m searching for an existing exact <b>${APP_NAME}</b> custom app.${wait}`);
     case "plugin-add":
-      return copy(
-        "6 · Create the app",
-        `No existing <b>GitHub MCP</b> app was found. Click the highlighted <b>Create app</b> button.${wait}`,
-      );
+      return copy("6 · Opening custom app setup", `No existing custom <b>${APP_NAME}</b> was found. I’m opening ChatGPT’s Create app form.${wait}`);
     case "plugin-name":
-      return copy(
-        "7 · Name",
-        `Use <b>${SEARCH_VALUE}</b> so it is easy to recognize later.${wait}`,
-        primary("fill-name", `Use ${SEARCH_VALUE}`),
-      );
+      return copy("7 · Preparing name", `I’m filling <b>${APP_NAME}</b> in the current custom plugin form.${wait}`);
     case "plugin-server":
-      return copy(
-        "8 · Server URL",
-        `Put <code>${MCP_URL}</code> in the highlighted Server URL field.${wait}`,
-        primary("fill-url", "Fill server URL"),
-      );
+      return copy("8 · Preparing remote server", `I’m selecting Server URL and filling <code>${MCP_URL}</code>.${wait}`);
     case "plugin-auth":
-      return copy(
-        "9 · Authentication",
-        `Set Authentication to <b>OAuth</b> in the highlighted control.${wait}`,
-        primary("auth-next", "OAuth selected — next"),
-      );
-    default:
-      return guideCopyLate(step, wait);
-  }
-}
-
-function guideCopyLate(step: SetupGuideStep, wait: string): GuideCopy {
-  switch (step) {
+      return copy("9 · Preparing OAuth", `I’m selecting <b>OAuth</b> in ChatGPT’s Authentication field.${wait}`);
     case "plugin-risk":
       return copy(
-        "10 · Risk acknowledgement",
-        `Read the warning, then check the highlighted acknowledgement.${wait}`,
-        primary("risk-next", "Checked — next"),
+        "10 · Your approval required",
+        `ChatGPT requires you to read and check the highlighted <b>I understand and want to continue</b> acknowledgement. Chat FreePT will never approve this risk disclosure for you.${wait}`,
       );
     case "plugin-create":
-      return copy("11 · Create", `Click the highlighted <b>Create</b> button.${wait}`);
+      return copy(
+        "11 · Create and authorize",
+        `The safe fields are prepared. Review them, then click the highlighted <b>Create</b> button. ChatGPT may open GitHub OAuth; approve only the repository/workflow access you intend to grant.${wait}`,
+      );
     case "oauth":
       return copy(
-        "12 · Complete GitHub OAuth",
-        "Finish the GitHub authorization ChatGPT opens. Approve the repository and workflow write permissions you intend Chat FreePT to use, then return here.",
-        primary("return-chat", "Connected — return to chat"),
-      );
-    case "chat-plus":
-      return copy(
-        "13 · Add it to this chat",
-        `Click the highlighted <b>+</b> beside the composer.${wait}`,
-      );
-    case "developer-menu":
-      return copy(
-        "14 · Developer mode",
-        `Choose the highlighted <b>Developer mode</b> entry. If GitHub MCP appears directly, choose it instead.${wait}`,
-      );
-    case "github-app":
-      return copy(
-        "15 · GitHub MCP",
-        `Choose the highlighted <b>GitHub MCP</b> plugin for this conversation.${wait}`,
+        "12 · Finish GitHub OAuth",
+        "Complete GitHub authorization. If ChatGPT returns here and the custom app becomes visible, I’ll return to your chat automatically; otherwise use the button below after OAuth finishes.",
+        primary("return-chat", "OAuth finished — return to chat"),
       );
     case "done":
       return copy(
         "Setup complete",
-        "Chat FreePT can now run its GitHub capability preflight in this conversation.",
+        "You’re back in the conversation. There is no extra GitHub MCP menu step to guess at: Chat FreePT’s next GitHub preflight will inspect the tools actually exposed here and stop with NEEDS_INPUT if the host did not attach the required capabilities.",
         primary("finish", "Done"),
       );
-    default:
-      return copy("Setup", `Continue with the highlighted ChatGPT control.${wait}`);
   }
 }
 
@@ -660,7 +586,8 @@ function isControlEnabled(element: HTMLElement): boolean {
   if (element instanceof HTMLInputElement) return element.checked;
   return (
     element.getAttribute("aria-checked") === "true" ||
-    element.getAttribute("data-state") === "checked"
+    element.getAttribute("data-state") === "checked" ||
+    element.getAttribute("data-state") === "on"
   );
 }
 
@@ -674,19 +601,33 @@ function fieldValue(element: HTMLElement | null): string {
 function controlValue(element: HTMLElement | null): string {
   if (!element) return "";
   if (element instanceof HTMLSelectElement || element instanceof HTMLInputElement) {
-    return element.value.toLowerCase();
+    const selectedText = element instanceof HTMLSelectElement ? element.selectedOptions[0]?.textContent ?? "" : "";
+    return `${element.value} ${selectedText}`.toLowerCase();
   }
   return `${element.getAttribute("data-value") ?? ""} ${element.textContent ?? ""}`.toLowerCase();
 }
 
+function sameUrl(left: string, right: string): boolean {
+  return left.trim().replace(/\/$/, "").toLowerCase() === right.replace(/\/$/, "").toLowerCase();
+}
+
 function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
   const prototype =
-    element instanceof HTMLInputElement
-      ? HTMLInputElement.prototype
-      : HTMLTextAreaElement.prototype;
+    element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
   const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
   if (setter) setter.call(element, value);
   else element.value = value;
+  dispatchFieldEvents(element);
+}
+
+function setNativeSelectValue(element: HTMLSelectElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set;
+  if (setter) setter.call(element, value);
+  else element.value = value;
+  dispatchFieldEvents(element);
+}
+
+function dispatchFieldEvents(element: HTMLElement): void {
   element.dispatchEvent(new Event("input", { bubbles: true }));
   element.dispatchEvent(new Event("change", { bubbles: true }));
 }
@@ -699,8 +640,7 @@ function settingsScrollContainer(target: HTMLElement): HTMLElement | null {
     node = node.parentElement;
   }
 
-  const modal =
-    target.closest<HTMLElement>("#modal-settings") ?? document.getElementById("modal-settings");
+  const modal = target.closest<HTMLElement>("#modal-settings") ?? document.getElementById("modal-settings");
   return modal?.querySelector<HTMLElement>('[class*="overflow-y-auto"]') ?? null;
 }
 

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -314,7 +314,8 @@ export class SetupGuide {
 
   private autoSearchForPlugin(): boolean {
     const search = queryGuideTarget("pluginSearchInput");
-    if (!(search instanceof HTMLInputElement || search instanceof HTMLTextAreaElement)) return false;
+    if (!(search instanceof HTMLInputElement || search instanceof HTMLTextAreaElement))
+      return false;
     if (fieldValue(search).trim().toLowerCase() !== APP_NAME.toLowerCase()) {
       setNativeValue(search, APP_NAME);
     }
@@ -513,7 +514,10 @@ function guideCopy(step: SetupGuideStep, found: boolean): GuideCopy {
   const wait = found ? "" : " I’m waiting for this ChatGPT control to appear.";
   switch (step) {
     case "security":
-      return copy("1 · Security and login", `Click the highlighted <b>Security and login</b> item.${wait}`);
+      return copy(
+        "1 · Security and login",
+        `Click the highlighted <b>Security and login</b> item.${wait}`,
+      );
     case "developer":
       return copy(
         "2 · Developer mode",
@@ -532,15 +536,30 @@ function guideCopy(step: SetupGuideStep, found: boolean): GuideCopy {
         primary("open-plugins", "Open Plugins"),
       );
     case "plugin-search":
-      return copy("5 · Checking for GitHub MCP", `I’m searching for an existing exact <b>${APP_NAME}</b> custom app.${wait}`);
+      return copy(
+        "5 · Checking for GitHub MCP",
+        `I’m searching for an existing exact <b>${APP_NAME}</b> custom app.${wait}`,
+      );
     case "plugin-add":
-      return copy("6 · Opening custom app setup", `No existing custom <b>${APP_NAME}</b> was found. I’m opening ChatGPT’s Create app form.${wait}`);
+      return copy(
+        "6 · Opening custom app setup",
+        `No existing custom <b>${APP_NAME}</b> was found. I’m opening ChatGPT’s Create app form.${wait}`,
+      );
     case "plugin-name":
-      return copy("7 · Preparing name", `I’m filling <b>${APP_NAME}</b> in the current custom plugin form.${wait}`);
+      return copy(
+        "7 · Preparing name",
+        `I’m filling <b>${APP_NAME}</b> in the current custom plugin form.${wait}`,
+      );
     case "plugin-server":
-      return copy("8 · Preparing remote server", `I’m selecting Server URL and filling <code>${MCP_URL}</code>.${wait}`);
+      return copy(
+        "8 · Preparing remote server",
+        `I’m selecting Server URL and filling <code>${MCP_URL}</code>.${wait}`,
+      );
     case "plugin-auth":
-      return copy("9 · Preparing OAuth", `I’m selecting <b>OAuth</b> in ChatGPT’s Authentication field.${wait}`);
+      return copy(
+        "9 · Preparing OAuth",
+        `I’m selecting <b>OAuth</b> in ChatGPT’s Authentication field.${wait}`,
+      );
     case "plugin-risk":
       return copy(
         "10 · Your approval required",
@@ -601,7 +620,8 @@ function fieldValue(element: HTMLElement | null): string {
 function controlValue(element: HTMLElement | null): string {
   if (!element) return "";
   if (element instanceof HTMLSelectElement || element instanceof HTMLInputElement) {
-    const selectedText = element instanceof HTMLSelectElement ? element.selectedOptions[0]?.textContent ?? "" : "";
+    const selectedText =
+      element instanceof HTMLSelectElement ? (element.selectedOptions[0]?.textContent ?? "") : "";
     return `${element.value} ${selectedText}`.toLowerCase();
   }
   return `${element.getAttribute("data-value") ?? ""} ${element.textContent ?? ""}`.toLowerCase();
@@ -613,7 +633,9 @@ function sameUrl(left: string, right: string): boolean {
 
 function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
   const prototype =
-    element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+    element instanceof HTMLInputElement
+      ? HTMLInputElement.prototype
+      : HTMLTextAreaElement.prototype;
   const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
   if (setter) setter.call(element, value);
   else element.value = value;
@@ -640,7 +662,8 @@ function settingsScrollContainer(target: HTMLElement): HTMLElement | null {
     node = node.parentElement;
   }
 
-  const modal = target.closest<HTMLElement>("#modal-settings") ?? document.getElementById("modal-settings");
+  const modal =
+    target.closest<HTMLElement>("#modal-settings") ?? document.getElementById("modal-settings");
   return modal?.querySelector<HTMLElement>('[class*="overflow-y-auto"]') ?? null;
 }
 

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -27,11 +27,12 @@ interface GuideCopy {
   actions: string;
 }
 
-const SESSION_KEY = "cfpt:setup-guide:v3";
-const MCP_URL = "https://api.githubcopilot.com/mcp/";
+const SESSION_KEY = "cfpt:setup-guide:v4";
+const MCP_URL = "https://api.githubcopilot.com/mcp/x/all";
 const PLUGINS_URL = "https://chatgpt.com/plugins";
-const APP_NAME = "GitHub MCP";
+const APP_NAME = "Chat FreePT GitHub MCP";
 const SCROLL_RETRY_MS = 150;
+const SEARCH_SETTLE_MS = 800;
 
 const GUIDE_STEPS = new Set<SetupGuideStep>([
   "security",
@@ -203,11 +204,13 @@ export class SetupGuide {
   private readonly onViewportChange = (): void => this.render();
 
   private readonly onPageClick = (event: Event): void => {
-    if (!this.active) return;
+    if (!this.active || this.step !== "plugin-risk") return;
     const target = this.currentTarget();
     const clicked = event.target instanceof Node ? event.target : null;
     if (!target || !clicked || !target.contains(clicked)) return;
-    this.afterTargetClick(target);
+    setTimeout(() => {
+      if (isControlEnabled(target)) void this.setStep("plugin-create");
+    }, 80);
   };
 
   private restore(): void {
@@ -265,23 +268,56 @@ export class SetupGuide {
   }
 
   private advanceSettingsStep(): boolean {
+    if (this.step === "security") return this.advanceSecurity();
+    if (this.step === "developer") return this.advanceDeveloperRow();
+    if (this.step === "developer-toggle") return this.advanceDeveloperToggle();
+    return false;
+  }
+
+  private advanceSecurity(): boolean {
     const toggle = queryGuideTarget("developerModeToggle");
-    if (this.step === "security" && toggle) {
-      void this.setStep("developer");
+    if (toggle) {
+      void this.setStep("developer-toggle");
       return true;
     }
-    if ((this.step === "developer" || this.step === "developer-toggle") && toggle) {
-      if (isControlEnabled(toggle)) {
-        void this.setStep("plugins");
-        return true;
-      }
+    const security = queryGuideTarget("settingsSecurity");
+    if (!security) return false;
+    this.runOnce("security", () => {
+      security.click();
+      setTimeout(() => {
+        if (this.step === "security") void this.setStep("developer");
+      }, 120);
+    });
+    return false;
+  }
+
+  private advanceDeveloperRow(): boolean {
+    const toggle = queryGuideTarget("developerModeToggle");
+    if (!toggle) return false;
+    void this.setStep("developer-toggle");
+    return true;
+  }
+
+  private advanceDeveloperToggle(): boolean {
+    const toggle = queryGuideTarget("developerModeToggle");
+    if (!toggle) return false;
+    if (isControlEnabled(toggle)) {
+      this.openPlugins();
+      return true;
     }
+    this.runOnce("developer-toggle", () => {
+      toggle.click();
+      setTimeout(() => this.render(), 180);
+    });
     return false;
   }
 
   private advancePluginStep(): boolean {
     if (this.existingPluginCompletesSetup()) return true;
     switch (this.step) {
+      case "plugins":
+        this.runOnce("plugins", () => this.openPlugins());
+        return false;
       case "plugin-search":
         return this.autoSearchForPlugin();
       case "plugin-add":
@@ -292,15 +328,20 @@ export class SetupGuide {
         return this.autoFillServer();
       case "plugin-auth":
         return this.autoSelectOauth();
-      case "plugin-risk": {
-        const risk = queryGuideTarget("pluginRiskCheckbox");
-        if (!risk || !isControlEnabled(risk)) return false;
-        void this.setStep("plugin-create");
-        return true;
-      }
+      case "plugin-risk":
+        return this.advanceRiskApproval();
+      case "plugin-create":
+        return this.autoCreateAfterApproval();
       default:
         return false;
     }
+  }
+
+  private advanceRiskApproval(): boolean {
+    const risk = queryGuideTarget("pluginRiskCheckbox");
+    if (!risk || !isControlEnabled(risk)) return false;
+    void this.setStep("plugin-create");
+    return true;
   }
 
   private existingPluginCompletesSetup(): boolean {
@@ -314,23 +355,30 @@ export class SetupGuide {
 
   private autoSearchForPlugin(): boolean {
     const search = queryGuideTarget("pluginSearchInput");
-    if (!(search instanceof HTMLInputElement || search instanceof HTMLTextAreaElement))
+    if (!(search instanceof HTMLInputElement || search instanceof HTMLTextAreaElement)) {
       return false;
+    }
     if (fieldValue(search).trim().toLowerCase() !== APP_NAME.toLowerCase()) {
       setNativeValue(search, APP_NAME);
     }
-    return this.oncePerStep("plugin-search", () => {
-      setTimeout(() => void this.setStep("plugin-add"), 300);
+    this.runOnce("plugin-search", () => {
+      setTimeout(() => {
+        if (this.step === "plugin-search") void this.setStep("plugin-add");
+      }, SEARCH_SETTLE_MS);
     });
+    return false;
   }
 
   private autoOpenCreateForm(): boolean {
     const create = queryGuideTarget("pluginAddButton");
     if (!create) return false;
-    return this.oncePerStep("plugin-add", () => {
+    this.runOnce("plugin-add", () => {
       create.click();
-      setTimeout(() => void this.setStep("plugin-name"), 100);
+      setTimeout(() => {
+        if (this.step === "plugin-add") void this.setStep("plugin-name");
+      }, 120);
     });
+    return false;
   }
 
   private autoFillName(): boolean {
@@ -344,7 +392,11 @@ export class SetupGuide {
   private autoFillServer(): boolean {
     const option = queryGuideTarget("pluginServerUrlOption");
     if (option && !isControlEnabled(option)) {
-      return this.oncePerStep("plugin-server", () => option.click());
+      this.runOnce("plugin-server", () => {
+        option.click();
+        setTimeout(() => this.render(), 100);
+      });
+      return false;
     }
     const input = queryGuideTarget("pluginServerInput");
     if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) return false;
@@ -356,19 +408,42 @@ export class SetupGuide {
   private autoSelectOauth(): boolean {
     const auth = queryGuideTarget("pluginAuthControl");
     if (!auth) return false;
-    if (auth instanceof HTMLSelectElement && auth.value.toUpperCase() !== "OAUTH") {
-      setNativeSelectValue(auth, "OAUTH");
+    if (auth instanceof HTMLSelectElement) {
+      if (auth.value.toUpperCase() !== "OAUTH") setNativeSelectValue(auth, "OAUTH");
+      void this.setStep("plugin-risk");
+      return true;
     }
-    if (!controlValue(auth).includes("oauth")) return false;
-    void this.setStep("plugin-risk");
-    return true;
+    if (controlValue(auth).includes("oauth")) {
+      void this.setStep("plugin-risk");
+      return true;
+    }
+    this.runOnce("plugin-auth", () => {
+      auth.click();
+      setTimeout(() => {
+        const oauth = queryGuideTarget("pluginOauthOption");
+        if (oauth && oauth !== auth) oauth.click();
+        setTimeout(() => this.render(), 80);
+      }, 80);
+    });
+    return false;
   }
 
-  private oncePerStep(step: SetupGuideStep, action: () => void): boolean {
-    if (this.autoActionStep === step) return true;
+  private autoCreateAfterApproval(): boolean {
+    const create = queryGuideTarget("pluginCreateButton");
+    if (!create || isDisabled(create)) return false;
+    this.runOnce("plugin-create", () => {
+      create.click();
+      setTimeout(() => {
+        if (this.step === "plugin-create") void this.setStep("oauth");
+      }, 120);
+    });
+    return false;
+  }
+
+  private runOnce(step: SetupGuideStep, action: () => void): void {
+    if (this.autoActionStep === step) return;
     this.autoActionStep = step;
     action();
-    return true;
   }
 
   private hide(): void {
@@ -434,31 +509,6 @@ export class SetupGuide {
     return false;
   }
 
-  private afterTargetClick(target: HTMLElement): void {
-    switch (this.step) {
-      case "security":
-        this.deferStep("developer");
-        break;
-      case "developer-toggle":
-        setTimeout(() => {
-          if (isControlEnabled(target)) void this.setStep("plugins");
-        }, 120);
-        break;
-      case "plugin-risk":
-        setTimeout(() => {
-          if (isControlEnabled(target)) void this.setStep("plugin-create");
-        }, 80);
-        break;
-      case "plugin-create":
-        this.deferStep("oauth");
-        break;
-    }
-  }
-
-  private deferStep(step: SetupGuideStep): void {
-    setTimeout(() => void this.setStep(step), 80);
-  }
-
   private async setStep(step: SetupGuideStep): Promise<void> {
     this.step = step;
     this.resetStepTracking();
@@ -478,8 +528,6 @@ export class SetupGuide {
     event.stopPropagation();
     const action = target.dataset["guideAction"];
     if (action === "cancel") void this.cancel();
-    else if (action === "developer-next") void this.setStep("developer-toggle");
-    else if (action === "open-plugins") this.openPlugins();
     else if (action === "return-chat") this.returnToChat();
     else if (action === "finish") void this.finish();
   }
@@ -515,45 +563,43 @@ function guideCopy(step: SetupGuideStep, found: boolean): GuideCopy {
   switch (step) {
     case "security":
       return copy(
-        "1 · Security and login",
-        `Click the highlighted <b>Security and login</b> item.${wait}`,
+        "1 · Opening Security and login",
+        `I’m opening <b>Security and login</b> for you.${wait}`,
       );
     case "developer":
       return copy(
-        "2 · Developer mode",
-        `Developer mode is lower on this page. I’ll bring the row into the Settings viewport before highlighting it.${wait}`,
-        primary("developer-next", "Show the switch"),
+        "2 · Finding Developer mode",
+        `Developer mode is lower on this page. I’ll bring it into view automatically.${wait}`,
       );
     case "developer-toggle":
       return copy(
-        "3 · Enable Developer mode",
-        `Turn on the highlighted <b>Developer mode</b> switch. If it is already on, I skip this step automatically.${wait}`,
+        "3 · Enabling Developer mode",
+        `I’m turning on the highlighted <b>Developer mode</b> switch. If ChatGPT opens an additional warning or confirmation, you must approve that prompt yourself.${wait}`,
       );
     case "plugins":
       return copy(
-        "4 · Open Plugins",
-        "Developer mode is ready. Open Plugins; from there I’ll check for an existing custom GitHub MCP and prepare the form automatically.",
-        primary("open-plugins", "Open Plugins"),
+        "4 · Opening Plugins",
+        "Developer mode is ready. I’m opening Plugins automatically.",
       );
     case "plugin-search":
       return copy(
-        "5 · Checking for GitHub MCP",
-        `I’m searching for an existing exact <b>${APP_NAME}</b> custom app.${wait}`,
+        "5 · Checking Chat FreePT GitHub MCP",
+        `I’m searching for an existing exact <b>${APP_NAME}</b> custom app before creating anything.${wait}`,
       );
     case "plugin-add":
       return copy(
         "6 · Opening custom app setup",
-        `No existing custom <b>${APP_NAME}</b> was found. I’m opening ChatGPT’s Create app form.${wait}`,
+        `No existing <b>${APP_NAME}</b> was found. I’m opening ChatGPT’s Create app form.${wait}`,
       );
     case "plugin-name":
       return copy(
-        "7 · Preparing name",
-        `I’m filling <b>${APP_NAME}</b> in the current custom plugin form.${wait}`,
+        "7 · Preparing app name",
+        `I’m filling <b>${APP_NAME}</b>.${wait}`,
       );
     case "plugin-server":
       return copy(
-        "8 · Preparing remote server",
-        `I’m selecting Server URL and filling <code>${MCP_URL}</code>.${wait}`,
+        "8 · Preparing full GitHub toolset",
+        `I’m selecting Server URL and filling <code>${MCP_URL}</code>, GitHub’s remote all-toolsets endpoint.${wait}`,
       );
     case "plugin-auth":
       return copy(
@@ -563,23 +609,23 @@ function guideCopy(step: SetupGuideStep, found: boolean): GuideCopy {
     case "plugin-risk":
       return copy(
         "10 · Your approval required",
-        `ChatGPT requires you to read and check the highlighted <b>I understand and want to continue</b> acknowledgement. Chat FreePT will never approve this risk disclosure for you.${wait}`,
+        `ChatGPT requires you to read and check the highlighted <b>I understand and want to continue</b> acknowledgement. Chat FreePT will never approve this risk disclosure for you. Once you check it, I’ll press Create automatically.${wait}`,
       );
     case "plugin-create":
       return copy(
-        "11 · Create and authorize",
-        `The safe fields are prepared. Review them, then click the highlighted <b>Create</b> button. ChatGPT may open GitHub OAuth; approve only the repository/workflow access you intend to grant.${wait}`,
+        "11 · Creating the custom MCP",
+        `Your risk acknowledgement is complete. I’m pressing <b>Create</b> and continuing to GitHub OAuth automatically.${wait}`,
       );
     case "oauth":
       return copy(
         "12 · Finish GitHub OAuth",
-        "Complete GitHub authorization. If ChatGPT returns here and the custom app becomes visible, I’ll return to your chat automatically; otherwise use the button below after OAuth finishes.",
+        "GitHub authorization is the remaining external consent step. Complete OAuth and approve only the access you intend to grant. When ChatGPT shows the custom app afterward, I’ll return to your original chat automatically; use the button below only if the host does not refresh on its own.",
         primary("return-chat", "OAuth finished — return to chat"),
       );
     case "done":
       return copy(
         "Setup complete",
-        "You’re back in the conversation. There is no extra GitHub MCP menu step to guess at: Chat FreePT’s next GitHub preflight will inspect the tools actually exposed here and stop with NEEDS_INPUT if the host did not attach the required capabilities.",
+        "You’re back in the conversation. Chat FreePT’s next GitHub preflight will inspect the tools actually exposed by the custom MCP and stop with NEEDS_INPUT if any required repository, Issue, label, PR, Git or Actions capability is still missing.",
         primary("finish", "Done"),
       );
   }
@@ -608,6 +654,11 @@ function isControlEnabled(element: HTMLElement): boolean {
     element.getAttribute("data-state") === "checked" ||
     element.getAttribute("data-state") === "on"
   );
+}
+
+function isDisabled(element: HTMLElement): boolean {
+  if (element instanceof HTMLButtonElement) return element.disabled;
+  return element.getAttribute("aria-disabled") === "true";
 }
 
 function fieldValue(element: HTMLElement | null): string {

--- a/src/content/ui/setup-guide.ts
+++ b/src/content/ui/setup-guide.ts
@@ -592,10 +592,7 @@ function guideCopy(step: SetupGuideStep, found: boolean): GuideCopy {
         `No existing <b>${APP_NAME}</b> was found. I’m opening ChatGPT’s Create app form.${wait}`,
       );
     case "plugin-name":
-      return copy(
-        "7 · Preparing app name",
-        `I’m filling <b>${APP_NAME}</b>.${wait}`,
-      );
+      return copy("7 · Preparing app name", `I’m filling <b>${APP_NAME}</b>.${wait}`);
     case "plugin-server":
       return copy(
         "8 · Preparing full GitHub toolset",

--- a/tests/page-mode.test.ts
+++ b/tests/page-mode.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { chatGptPageMode } from "../src/content/page-mode";
+
+describe("ChatGPT page mode", () => {
+  it("treats Plugins as a setup route without a composer", () => {
+    expect(chatGptPageMode("https://chatgpt.com/plugins")).toBe("plugins");
+    expect(
+      chatGptPageMode(
+        "https://chatgpt.com/plugins#settings/Connectors?create-connector=true&redirectAfter=%2Fplugins",
+      ),
+    ).toBe("plugins");
+  });
+
+  it("treats Library and Scheduled as expected utility pages", () => {
+    expect(chatGptPageMode("https://chatgpt.com/library")).toBe("utility");
+    expect(chatGptPageMode("https://chatgpt.com/scheduled")).toBe("utility");
+  });
+
+  it("keeps normal and conversation URLs in composer mode", () => {
+    expect(chatGptPageMode("https://chatgpt.com/")).toBe("composer");
+    expect(chatGptPageMode("https://chatgpt.com/c/abc-123")).toBe("composer");
+  });
+});

--- a/tests/page-mode.test.ts
+++ b/tests/page-mode.test.ts
@@ -4,6 +4,7 @@ import { chatGptPageMode } from "../src/content/page-mode";
 describe("ChatGPT page mode", () => {
   it("treats Plugins as a setup route without a composer", () => {
     expect(chatGptPageMode("https://chatgpt.com/plugins")).toBe("plugins");
+    expect(chatGptPageMode("https://chatgpt.com/plugins/custom/github-mcp")).toBe("plugins");
     expect(
       chatGptPageMode(
         "https://chatgpt.com/plugins#settings/Connectors?create-connector=true&redirectAfter=%2Fplugins",
@@ -13,6 +14,7 @@ describe("ChatGPT page mode", () => {
 
   it("treats Library and Scheduled as expected utility pages", () => {
     expect(chatGptPageMode("https://chatgpt.com/library")).toBe("utility");
+    expect(chatGptPageMode("https://chatgpt.com/library?entry_point=sidebar")).toBe("utility");
     expect(chatGptPageMode("https://chatgpt.com/scheduled")).toBe("utility");
   });
 

--- a/tests/panel.test.ts
+++ b/tests/panel.test.ts
@@ -172,7 +172,7 @@ describe("composer takeover lifecycle", () => {
 
     panel.toggle(false);
     expect(nativeSurface().style.pointerEvents).toBe("auto");
-    expect(nativeSurface().inert).toBe(false);
+    expect(nativeSurface().inert ?? false).toBe(false);
     expect(nativeSurface().getAttribute("aria-hidden")).toBe("false");
     expect(nativeSurface().dataset["cfptTakeover"]).toBeUndefined();
   });

--- a/tests/panel.test.ts
+++ b/tests/panel.test.ts
@@ -56,10 +56,24 @@ function overlayShadow(): ShadowRoot {
   return root;
 }
 
+function launcherButton(): HTMLButtonElement {
+  for (const root of shadows) {
+    const button = root.querySelector<HTMLButtonElement>(".cfpt-launcher");
+    if (button) return button;
+  }
+  throw new Error("Chat FreePT launcher button missing");
+}
+
 function nativeSurface(): HTMLElement {
   const surface = document.querySelector<HTMLElement>('[data-composer-surface="true"]');
   if (!surface) throw new Error("native composer surface missing");
   return surface;
+}
+
+function nativeComposer(): HTMLElement {
+  const composer = document.getElementById("prompt-textarea");
+  if (!composer) throw new Error("native composer input missing");
+  return composer;
 }
 
 function onboardingDone(): void {
@@ -141,21 +155,52 @@ describe("native composer launcher placement", () => {
 });
 
 describe("composer takeover lifecycle", () => {
-  it("blocks the native composer while open and restores its exact state on close", () => {
+  it("moves native focus, uses inert, and restores the exact native state on close", () => {
     onboardingDone();
     const panel = makePanel();
     panel.render(newRunState("conversation-1", 1));
+    nativeComposer().focus();
+    expect(document.activeElement).toBe(nativeComposer());
 
     panel.toggle(true);
     expect(nativeSurface().style.pointerEvents).toBe("none");
-    expect(nativeSurface().getAttribute("aria-hidden")).toBe("true");
+    expect(nativeSurface().inert).toBe(true);
+    expect(nativeSurface().getAttribute("aria-hidden")).toBe("false");
     expect(nativeSurface().dataset["cfptTakeover"]).toBe("true");
+    expect(document.activeElement).not.toBe(nativeComposer());
     expect(host().dataset["expanded"]).toBe("true");
 
     panel.toggle(false);
     expect(nativeSurface().style.pointerEvents).toBe("auto");
+    expect(nativeSurface().inert).toBe(false);
     expect(nativeSurface().getAttribute("aria-hidden")).toBe("false");
     expect(nativeSurface().dataset["cfptTakeover"]).toBeUndefined();
+  });
+
+  it("restores a composer that was already inert before takeover", () => {
+    onboardingDone();
+    nativeSurface().inert = true;
+    const panel = makePanel();
+    panel.render(newRunState("conversation-1", 1));
+
+    panel.toggle(true);
+    panel.toggle(false);
+    expect(nativeSurface().inert).toBe(true);
+  });
+
+  it("does not leak launcher events into ChatGPT composer controls", () => {
+    onboardingDone();
+    makePanel().render(newRunState("conversation-1", 1));
+    const nativeHandler = vi.fn();
+    host().parentElement?.addEventListener("pointerdown", nativeHandler);
+    host().parentElement?.addEventListener("mousedown", nativeHandler);
+    host().parentElement?.addEventListener("click", nativeHandler);
+
+    launcherButton().dispatchEvent(new Event("pointerdown", { bubbles: true, composed: true }));
+    launcherButton().dispatchEvent(new MouseEvent("mousedown", { bubbles: true, composed: true }));
+    launcherButton().dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+
+    expect(nativeHandler).not.toHaveBeenCalled();
   });
 
   it("closes when the user clicks outside the integrated panel", () => {
@@ -223,6 +268,7 @@ describe("first-run and plan-aware setup", () => {
 
     expect(overlayShadow().textContent).toContain("Follow along");
     expect(overlayShadow().textContent).toContain("Using ChatGPT Free?");
+    expect(overlayShadow().textContent).toContain("fill the GitHub MCP name");
     overlayShadow().querySelector<HTMLButtonElement>('[data-action="free-setup"]')?.click();
     expect(overlayShadow().textContent).toContain("Prepare GitHub manually first");
     expect(overlayShadow().textContent).toContain("Existing repo");

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -67,11 +67,18 @@ describe("plan prompt", () => {
     expect(existing).toMatch(/only for labels that are actually\s+missing/);
   });
 
-  it("uses current Developer Mode setup and does not require default-branch mutation", () => {
+  it("uses the current custom MCP setup flow and does not require default-branch mutation", () => {
     const prompt = buildPlanPrompt(planInput);
     expect(prompt).toContain("Settings → Security and login → Developer mode");
     expect(prompt).toContain("https://chatgpt.com/plugins");
+    expect(prompt).toContain("Create app");
+    expect(prompt).toContain("GitHub MCP");
+    expect(prompt).toContain("Server URL");
     expect(prompt).toContain("https://api.githubcopilot.com/mcp/");
+    expect(prompt).toContain("OAuth");
+    expect(prompt).toContain("run this capability preflight again");
+    expect(prompt).not.toContain("open the Plus menu");
+    expect(prompt).not.toContain("choose Developer mode, and select");
     expect(prompt).toContain("Repository default-branch mutation is NOT required");
     expect(prompt).toContain("Do NOT require changing the repository default branch");
     expect(prompt).not.toContain("set dev as the default branch");

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -67,15 +67,16 @@ describe("plan prompt", () => {
     expect(existing).toMatch(/only for labels that are actually\s+missing/);
   });
 
-  it("uses the current custom MCP setup flow and does not require default-branch mutation", () => {
+  it("uses the automated full-toolset custom MCP flow and does not require default-branch mutation", () => {
     const prompt = buildPlanPrompt(planInput);
-    expect(prompt).toContain("Settings → Security and login → Developer mode");
+    expect(prompt).toContain("Settings → Security and login");
     expect(prompt).toContain("https://chatgpt.com/plugins");
-    expect(prompt).toContain("Create app");
-    expect(prompt).toContain("GitHub MCP");
+    expect(prompt).toContain("Chat FreePT GitHub MCP");
     expect(prompt).toContain("Server URL");
-    expect(prompt).toContain("https://api.githubcopilot.com/mcp/");
+    expect(prompt).toContain("https://api.githubcopilot.com/mcp/x/all");
+    expect(prompt).toContain("all available MCP toolsets");
     expect(prompt).toContain("OAuth");
+    expect(prompt).toContain("press Create after I explicitly check");
     expect(prompt).toContain("run this capability preflight again");
     expect(prompt).not.toContain("open the Plus menu");
     expect(prompt).not.toContain("choose Developer mode, and select");

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -165,27 +165,28 @@ describe("composer and guided-setup targets", () => {
     );
   });
 
-  it("resolves the current Plugins search, Create app button, and only exact GitHub MCP result", () => {
+  it("resolves Plugins controls and only the dedicated Chat FreePT GitHub MCP result", () => {
     document.body.innerHTML = `
       <input id="plugin-search" placeholder="Search plugins" aria-label="Search plugins" value="GitHub" />
       <button aria-label="Create app"></button>
       <article><a aria-label="Open GitHub" href="/plugins/public-github">GitHub</a></article>
-      <article><a aria-label="Open GitHub MCP" href="/plugins/custom-github-mcp">GitHub MCP</a></article>`;
+      <article><a aria-label="Open GitHub MCP" href="/plugins/custom-github-mcp">GitHub MCP</a></article>
+      <article><a aria-label="Open Chat FreePT GitHub MCP" href="/plugins/custom-chat-freept-github-mcp">Chat FreePT GitHub MCP</a></article>`;
 
     expect(queryGuideTarget("pluginSearchInput")?.id).toBe("plugin-search");
     expect(queryGuideTarget("pluginAddButton")?.getAttribute("aria-label")).toBe("Create app");
     expect(queryGuideTarget("githubMcpPluginResult")?.getAttribute("aria-label")).toBe(
-      "Open GitHub MCP",
+      "Open Chat FreePT GitHub MCP",
     );
   });
 
-  it("does not mistake the public GitHub plugin for a custom GitHub MCP app", () => {
+  it("does not mistake public or legacy GitHub entries for the dedicated app", () => {
     document.body.innerHTML = `
       <input id="plugin-search" aria-label="Search plugins" value="GitHub" />
-      <article><a aria-label="Open GitHub" href="/plugins/public-github">GitHub</a></article>`;
+      <article><a aria-label="Open GitHub" href="/plugins/public-github">GitHub</a></article>
+      <article><a aria-label="Open GitHub MCP" href="/plugins/custom-github-mcp">GitHub MCP</a></article>`;
 
     expect(queryGuideTarget("githubMcpPluginResult")).toBeNull();
-    expect(queryGuideTarget("conversationGitHubMcp")).toBeNull();
   });
 
   it("prefers the exact current New Plugin form controls", () => {
@@ -198,7 +199,8 @@ describe("composer and guided-setup targets", () => {
             <button type="button" role="radio" aria-checked="false" aria-label="Tunnel">Tunnel</button>
           </div>
           <input id="custom-connector-url" inputmode="url" placeholder="https://example.com/sse" />
-          <select id="custom-connector-auth"><option value="OAUTH">OAuth</option></select>
+          <button role="combobox" aria-label="Authentication">No Auth</button>
+          <div role="option">OAuth</div>
           <label for="trust-checkbox"><input id="trust-checkbox" data-testid="trust-checkbox" type="checkbox" />I understand and want to continue</label>
           <button type="submit" disabled><div>Create</div></button>
         </form>
@@ -209,18 +211,21 @@ describe("composer and guided-setup targets", () => {
       "Server URL",
     );
     expect(queryGuideTarget("pluginServerInput")?.id).toBe("custom-connector-url");
-    expect(queryGuideTarget("pluginAuthControl")?.id).toBe("custom-connector-auth");
+    expect(queryGuideTarget("pluginAuthControl")?.getAttribute("aria-label")).toBe(
+      "Authentication",
+    );
+    expect(queryGuideTarget("pluginOauthOption")?.textContent).toBe("OAuth");
     expect(queryGuideTarget("pluginRiskCheckbox")?.id).toBe("trust-checkbox");
     expect(queryGuideTarget("pluginCreateButton")?.getAttribute("type")).toBe("submit");
   });
 
-  it("still resolves exact custom GitHub MCP if the conversation menu exposes it", () => {
+  it("still resolves either dedicated or legacy MCP names if a conversation menu exposes one", () => {
     document.body.innerHTML = `
       <div role="menu">
         <button role="menuitem">Developer mode</button>
-        <button role="menuitem">GitHub MCP</button>
+        <button role="menuitem">Chat FreePT GitHub MCP</button>
       </div>`;
     expect(queryGuideTarget("conversationDeveloperMode")?.textContent).toBe("Developer mode");
-    expect(queryGuideTarget("conversationGitHubMcp")?.textContent).toBe("GitHub MCP");
+    expect(queryGuideTarget("conversationGitHubMcp")?.textContent).toBe("Chat FreePT GitHub MCP");
   });
 });

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -185,26 +185,36 @@ describe("composer and guided-setup targets", () => {
       <article><a aria-label="Open GitHub" href="/plugins/public-github">GitHub</a></article>`;
 
     expect(queryGuideTarget("githubMcpPluginResult")).toBeNull();
+    expect(queryGuideTarget("conversationGitHubMcp")).toBeNull();
   });
 
-  it("resolves every field in the developer app form", () => {
+  it("prefers the exact current New Plugin form controls", () => {
     document.body.innerHTML = `
-      <button aria-label="Create app">+</button>
-      <label for="plugin-name">Name</label><input id="plugin-name" />
-      <label for="server-url">Server URL</label><input id="server-url" type="url" />
-      <label for="auth">Authentication</label><select id="auth"><option>OAuth</option></select>
-      <label><span>I understand the risks and want to continue</span><input id="risk" type="checkbox" /></label>
-      <button>Create</button>`;
+      <div id="modal-create-custom-connector">
+        <form>
+          <input id="custom-connector-name" aria-label="Name" placeholder="Custom Tool" />
+          <div role="radiogroup" aria-label="Connection">
+            <button type="button" role="radio" aria-checked="true" aria-label="Server URL">Server URL</button>
+            <button type="button" role="radio" aria-checked="false" aria-label="Tunnel">Tunnel</button>
+          </div>
+          <input id="custom-connector-url" inputmode="url" placeholder="https://example.com/sse" />
+          <select id="custom-connector-auth"><option value="OAUTH">OAuth</option></select>
+          <label for="trust-checkbox"><input id="trust-checkbox" data-testid="trust-checkbox" type="checkbox" />I understand and want to continue</label>
+          <button type="submit" disabled><div>Create</div></button>
+        </form>
+      </div>`;
 
-    expect(queryGuideTarget("pluginAddButton")?.getAttribute("aria-label")).toBe("Create app");
-    expect(queryGuideTarget("pluginNameInput")?.id).toBe("plugin-name");
-    expect(queryGuideTarget("pluginServerInput")?.id).toBe("server-url");
-    expect(queryGuideTarget("pluginAuthControl")?.id).toBe("auth");
-    expect(queryGuideTarget("pluginRiskCheckbox")?.id).toBe("risk");
-    expect(queryGuideTarget("pluginCreateButton")?.textContent).toBe("Create");
+    expect(queryGuideTarget("pluginNameInput")?.id).toBe("custom-connector-name");
+    expect(queryGuideTarget("pluginServerUrlOption")?.getAttribute("aria-label")).toBe(
+      "Server URL",
+    );
+    expect(queryGuideTarget("pluginServerInput")?.id).toBe("custom-connector-url");
+    expect(queryGuideTarget("pluginAuthControl")?.id).toBe("custom-connector-auth");
+    expect(queryGuideTarget("pluginRiskCheckbox")?.id).toBe("trust-checkbox");
+    expect(queryGuideTarget("pluginCreateButton")?.getAttribute("type")).toBe("submit");
   });
 
-  it("resolves Developer mode and GitHub MCP choices in the conversation menu", () => {
+  it("still resolves exact custom GitHub MCP if the conversation menu exposes it", () => {
     document.body.innerHTML = `
       <div role="menu">
         <button role="menuitem">Developer mode</button>

--- a/tests/setup-guide.test.ts
+++ b/tests/setup-guide.test.ts
@@ -166,6 +166,7 @@ describe("setup guide settings flow", () => {
     makeGuide();
     await settle();
 
+    // JSDOM does not clamp synthetic scrollTop like browsers; movement is the invariant.
     expect(scroller.scrollTop).not.toBe(0);
     expect(shadow.textContent).toContain("Developer mode");
   });

--- a/tests/setup-guide.test.ts
+++ b/tests/setup-guide.test.ts
@@ -143,9 +143,29 @@ describe("setup guide settings flow", () => {
       scrollHeight: { configurable: true, value: 1200 },
     });
     scroller.getBoundingClientRect = () =>
-      ({ top: 100, bottom: 500, height: 400, left: 0, right: 600, width: 600, x: 0, y: 100, toJSON: () => ({}) }) as DOMRect;
+      ({
+        top: 100,
+        bottom: 500,
+        height: 400,
+        left: 0,
+        right: 600,
+        width: 600,
+        x: 0,
+        y: 100,
+        toJSON: () => ({}),
+      }) as DOMRect;
     row.getBoundingClientRect = () =>
-      ({ top: 850, bottom: 920, height: 70, left: 100, right: 550, width: 450, x: 100, y: 850, toJSON: () => ({}) }) as DOMRect;
+      ({
+        top: 850,
+        bottom: 920,
+        height: 70,
+        left: 100,
+        right: 550,
+        width: 450,
+        x: 100,
+        y: 850,
+        toJSON: () => ({}),
+      }) as DOMRect;
 
     makeGuide();
     await settle();
@@ -208,18 +228,24 @@ describe("setup guide custom MCP automation", () => {
       document.body.insertAdjacentHTML("beforeend", customFormHtml());
       const auth = document.getElementById("custom-connector-auth") as HTMLSelectElement;
       auth.value = "NONE";
-      document.getElementById("custom-form")?.addEventListener("submit", (event) => event.preventDefault());
+      document
+        .getElementById("custom-form")
+        ?.addEventListener("submit", (event) => event.preventDefault());
     });
 
     makeGuide();
     await settle(600);
 
     expect((document.getElementById("plugin-search") as HTMLInputElement).value).toBe("GitHub MCP");
-    expect((document.getElementById("custom-connector-name") as HTMLInputElement).value).toBe("GitHub MCP");
+    expect((document.getElementById("custom-connector-name") as HTMLInputElement).value).toBe(
+      "GitHub MCP",
+    );
     expect((document.getElementById("custom-connector-url") as HTMLInputElement).value).toBe(
       "https://api.githubcopilot.com/mcp/",
     );
-    expect((document.getElementById("custom-connector-auth") as HTMLSelectElement).value).toBe("OAUTH");
+    expect((document.getElementById("custom-connector-auth") as HTMLSelectElement).value).toBe(
+      "OAUTH",
+    );
     expect((document.getElementById("trust-checkbox") as HTMLInputElement).checked).toBe(false);
     expect(sessionState()).toMatchObject({ step: "plugin-risk" });
     expect(shadow.textContent).toContain("never approve this risk disclosure for you");
@@ -235,7 +261,9 @@ describe("setup guide custom MCP automation", () => {
       create.disabled = false;
     });
     create.addEventListener("click", createClick);
-    document.getElementById("custom-form")?.addEventListener("submit", (event) => event.preventDefault());
+    document
+      .getElementById("custom-form")
+      ?.addEventListener("submit", (event) => event.preventDefault());
     makeGuide();
     await settle();
 

--- a/tests/setup-guide.test.ts
+++ b/tests/setup-guide.test.ts
@@ -166,8 +166,8 @@ describe("setup guide settings flow", () => {
     makeGuide();
     await settle();
 
-    expect(scroller.scrollTop).toBeGreaterThan(0);
-    expect(shadow.textContent).toContain("Finding Developer mode");
+    expect(scroller.scrollTop).not.toBe(0);
+    expect(shadow.textContent).toContain("Developer mode");
   });
 
   it("skips the Developer switch when it is already enabled and opens Plugins", async () => {

--- a/tests/setup-guide.test.ts
+++ b/tests/setup-guide.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SetupGuide } from "../src/content/ui/setup-guide";
 import { installChromeMock } from "./chrome-mock";
 
-const SESSION_KEY = "cfpt:setup-guide:v3";
+const SESSION_KEY = "cfpt:setup-guide:v4";
 let stores: ReturnType<typeof installChromeMock>;
 let shadow: ShadowRoot;
 let attachShadowSpy: ReturnType<typeof vi.spyOn>;
@@ -91,21 +91,17 @@ describe("setup guide tab isolation", () => {
     expect(stores.local["cfpt:setup-guide:v1"]).toMatchObject({ step: "developer-toggle" });
   });
 
-  it("highlights Security and login, then advances in the same tab session", async () => {
+  it("automatically opens Security and login in the same tab session", async () => {
     stored("security");
     document.body.innerHTML = '<button id="security">Security and login</button>';
+    const security = document.getElementById("security") as HTMLButtonElement;
+    const clicked = vi.fn();
+    security.addEventListener("click", clicked);
     makeGuide();
-    await settle();
+    await settle(160);
 
-    const ring = shadow.querySelector(".cfpt-guide-ring");
-    expect(shadow.querySelectorAll(".cfpt-guide-ring")).toHaveLength(1);
-    expect(ring?.classList.contains("cfpt-guide-hidden")).toBe(false);
-    expect(shadow.textContent).toContain("1 · Security and login");
-
-    document.getElementById("security")?.click();
-    await settle(100);
+    expect(clicked).toHaveBeenCalledTimes(1);
     expect(sessionState()).toMatchObject({ step: "developer" });
-    expect(ring?.classList.contains("cfpt-guide-hidden")).toBe(true);
   });
 
   it("keeps cancellation local to this tab session", async () => {
@@ -171,10 +167,10 @@ describe("setup guide settings flow", () => {
     await settle();
 
     expect(scroller.scrollTop).toBeGreaterThan(0);
-    expect(shadow.textContent).toContain("Developer mode is lower on this page");
+    expect(shadow.textContent).toContain("Finding Developer mode");
   });
 
-  it("skips Developer mode when the semantic switch is already enabled", async () => {
+  it("skips the Developer switch when it is already enabled and opens Plugins", async () => {
     stored("developer-toggle");
     document.body.innerHTML = `
       <section>
@@ -184,25 +180,27 @@ describe("setup guide settings flow", () => {
     makeGuide();
     await settle();
 
-    expect(sessionState()).toMatchObject({ step: "plugins" });
-    expect(shadow.textContent).toContain("4 · Open Plugins");
+    expect(sessionState()).toMatchObject({ step: "plugin-search" });
   });
 
-  it("advances after a disabled Developer mode switch becomes enabled", async () => {
+  it("turns on Developer mode automatically after Follow along", async () => {
     stored("developer-toggle");
     document.body.innerHTML = `
       <section>
         <span>Developer mode</span>
         <button id="developer-switch" role="switch" aria-label="Developer mode" aria-checked="false"></button>
       </section>`;
-    const toggle = document.getElementById("developer-switch");
-    toggle?.addEventListener("click", () => toggle.setAttribute("aria-checked", "true"));
+    const toggle = document.getElementById("developer-switch") as HTMLButtonElement;
+    const clicked = vi.fn();
+    toggle.addEventListener("click", () => {
+      clicked();
+      toggle.setAttribute("aria-checked", "true");
+    });
     makeGuide();
-    await settle();
+    await settle(260);
 
-    toggle?.click();
-    await settle(150);
-    expect(sessionState()).toMatchObject({ step: "plugins" });
+    expect(clicked).toHaveBeenCalledTimes(1);
+    expect(sessionState()).toMatchObject({ step: "plugin-search" });
   });
 });
 
@@ -218,7 +216,7 @@ describe("setup guide custom MCP automation", () => {
     expect(sessionState()).toMatchObject({ step: "plugin-risk" });
   });
 
-  it("searches, opens Create app, and fills safe MCP fields automatically", async () => {
+  it("searches, opens Create app, and fills all safe MCP fields automatically", async () => {
     stored("plugin-search");
     document.body.innerHTML = `
       <input id="plugin-search" aria-label="Search plugins" value="GitHub" />
@@ -234,14 +232,16 @@ describe("setup guide custom MCP automation", () => {
     });
 
     makeGuide();
-    await settle(600);
+    await settle(1100);
 
-    expect((document.getElementById("plugin-search") as HTMLInputElement).value).toBe("GitHub MCP");
+    expect((document.getElementById("plugin-search") as HTMLInputElement).value).toBe(
+      "Chat FreePT GitHub MCP",
+    );
     expect((document.getElementById("custom-connector-name") as HTMLInputElement).value).toBe(
-      "GitHub MCP",
+      "Chat FreePT GitHub MCP",
     );
     expect((document.getElementById("custom-connector-url") as HTMLInputElement).value).toBe(
-      "https://api.githubcopilot.com/mcp/",
+      "https://api.githubcopilot.com/mcp/x/all",
     );
     expect((document.getElementById("custom-connector-auth") as HTMLSelectElement).value).toBe(
       "OAUTH",
@@ -251,7 +251,7 @@ describe("setup guide custom MCP automation", () => {
     expect(shadow.textContent).toContain("never approve this risk disclosure for you");
   });
 
-  it("waits for explicit risk approval and explicit Create click", async () => {
+  it("waits for explicit risk approval, then presses Create automatically", async () => {
     stored("plugin-risk");
     document.body.innerHTML = customFormHtml();
     const risk = document.getElementById("trust-checkbox") as HTMLInputElement;
@@ -269,23 +269,20 @@ describe("setup guide custom MCP automation", () => {
 
     expect(risk.checked).toBe(false);
     expect(createClick).not.toHaveBeenCalled();
-    risk.click();
-    await settle(120);
-    expect(risk.checked).toBe(true);
-    expect(sessionState()).toMatchObject({ step: "plugin-create" });
-    expect(createClick).not.toHaveBeenCalled();
 
-    create.click();
-    await settle(120);
+    risk.click();
+    await settle(260);
+
+    expect(risk.checked).toBe(true);
     expect(createClick).toHaveBeenCalledTimes(1);
     expect(sessionState()).toMatchObject({ step: "oauth" });
   });
 
-  it("reuses an existing exact custom GitHub MCP and skips creation", async () => {
+  it("reuses an existing exact Chat FreePT GitHub MCP and skips creation", async () => {
     stored("plugin-search");
     document.body.innerHTML = `
-      <input id="plugin-search" aria-label="Search plugins" value="GitHub MCP" />
-      <article><a aria-label="Open GitHub MCP" href="/plugins/custom-github-mcp">GitHub MCP</a></article>`;
+      <input id="plugin-search" aria-label="Search plugins" value="Chat FreePT GitHub MCP" />
+      <article><a aria-label="Open Chat FreePT GitHub MCP" href="/plugins/custom-chat-freept-github-mcp">Chat FreePT GitHub MCP</a></article>`;
     makeGuide();
     await settle();
 

--- a/tests/setup-guide.test.ts
+++ b/tests/setup-guide.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SetupGuide } from "../src/content/ui/setup-guide";
 import { installChromeMock } from "./chrome-mock";
 
-const SESSION_KEY = "cfpt:setup-guide:v2";
+const SESSION_KEY = "cfpt:setup-guide:v3";
 let stores: ReturnType<typeof installChromeMock>;
 let shadow: ShadowRoot;
 let attachShadowSpy: ReturnType<typeof vi.spyOn>;
@@ -27,6 +27,29 @@ function makeGuide(): SetupGuide {
 
 async function settle(ms = 0): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function customFormHtml(): string {
+  return `
+    <div id="modal-create-custom-connector">
+      <form id="custom-form">
+        <input id="custom-connector-name" aria-label="Name" />
+        <div role="radiogroup" aria-label="Connection">
+          <button type="button" role="radio" aria-label="Server URL" aria-checked="true">Server URL</button>
+          <button type="button" role="radio" aria-label="Tunnel" aria-checked="false">Tunnel</button>
+        </div>
+        <input id="custom-connector-url" inputmode="url" />
+        <select id="custom-connector-auth">
+          <option value="NONE">No Auth</option>
+          <option value="OAUTH">OAuth</option>
+        </select>
+        <label for="trust-checkbox">
+          <input id="trust-checkbox" data-testid="trust-checkbox" type="checkbox" />
+          I understand and want to continue
+        </label>
+        <button id="create-custom" type="submit" disabled><span>Create</span></button>
+      </form>
+    </div>`;
 }
 
 beforeEach(() => {
@@ -97,9 +120,6 @@ describe("setup guide tab isolation", () => {
     expect(shadow.querySelector(".cfpt-guide-ring")?.classList.contains("cfpt-guide-hidden")).toBe(
       true,
     );
-    expect(shadow.querySelector(".cfpt-guide-card")?.classList.contains("cfpt-guide-hidden")).toBe(
-      true,
-    );
   });
 });
 
@@ -123,29 +143,9 @@ describe("setup guide settings flow", () => {
       scrollHeight: { configurable: true, value: 1200 },
     });
     scroller.getBoundingClientRect = () =>
-      ({
-        top: 100,
-        bottom: 500,
-        height: 400,
-        left: 0,
-        right: 600,
-        width: 600,
-        x: 0,
-        y: 100,
-        toJSON: () => ({}),
-      }) as DOMRect;
+      ({ top: 100, bottom: 500, height: 400, left: 0, right: 600, width: 600, x: 0, y: 100, toJSON: () => ({}) }) as DOMRect;
     row.getBoundingClientRect = () =>
-      ({
-        top: 850,
-        bottom: 920,
-        height: 70,
-        left: 100,
-        right: 550,
-        width: 450,
-        x: 100,
-        y: 850,
-        toJSON: () => ({}),
-      }) as DOMRect;
+      ({ top: 850, bottom: 920, height: 70, left: 100, right: 550, width: 450, x: 100, y: 850, toJSON: () => ({}) }) as DOMRect;
 
     makeGuide();
     await settle();
@@ -180,59 +180,88 @@ describe("setup guide settings flow", () => {
     makeGuide();
     await settle();
 
-    expect(shadow.textContent).toContain("3 · Enable Developer mode");
     toggle?.click();
     await settle(150);
     expect(sessionState()).toMatchObject({ step: "plugins" });
   });
 });
 
-describe("setup guide plugin flow", () => {
-  it("searches for the exact custom GitHub MCP app before offering Create app", async () => {
-    stored("plugin-search");
-    document.body.innerHTML = `
-      <input id="plugin-search" aria-label="Search plugins" value="GitHub" />
-      <button aria-label="Create app"></button>`;
+describe("setup guide custom MCP automation", () => {
+  it("resumes on Plugins without any conversation composer", async () => {
+    stored("plugin-risk");
+    document.body.innerHTML = customFormHtml();
     makeGuide();
     await settle();
 
-    shadow.querySelector<HTMLButtonElement>('[data-guide-action="search-plugin"]')?.click();
-    await settle(300);
-
-    expect((document.getElementById("plugin-search") as HTMLInputElement).value).toBe("GitHub MCP");
-    expect(sessionState()).toMatchObject({ step: "plugin-add" });
-    expect(shadow.textContent).toContain("Create the app");
+    expect(document.getElementById("prompt-textarea")).toBeNull();
+    expect(shadow.textContent).toContain("Your approval required");
+    expect(sessionState()).toMatchObject({ step: "plugin-risk" });
   });
 
-  it("skips custom app creation when an existing GitHub MCP result is present", async () => {
-    stored("plugin-add");
+  it("searches, opens Create app, and fills safe MCP fields automatically", async () => {
+    stored("plugin-search");
+    document.body.innerHTML = `
+      <input id="plugin-search" aria-label="Search plugins" value="GitHub" />
+      <button id="create-app" aria-label="Create app"></button>`;
+    const createApp = document.getElementById("create-app") as HTMLButtonElement;
+    createApp.addEventListener("click", () => {
+      document.body.insertAdjacentHTML("beforeend", customFormHtml());
+      const auth = document.getElementById("custom-connector-auth") as HTMLSelectElement;
+      auth.value = "NONE";
+      document.getElementById("custom-form")?.addEventListener("submit", (event) => event.preventDefault());
+    });
+
+    makeGuide();
+    await settle(600);
+
+    expect((document.getElementById("plugin-search") as HTMLInputElement).value).toBe("GitHub MCP");
+    expect((document.getElementById("custom-connector-name") as HTMLInputElement).value).toBe("GitHub MCP");
+    expect((document.getElementById("custom-connector-url") as HTMLInputElement).value).toBe(
+      "https://api.githubcopilot.com/mcp/",
+    );
+    expect((document.getElementById("custom-connector-auth") as HTMLSelectElement).value).toBe("OAUTH");
+    expect((document.getElementById("trust-checkbox") as HTMLInputElement).checked).toBe(false);
+    expect(sessionState()).toMatchObject({ step: "plugin-risk" });
+    expect(shadow.textContent).toContain("never approve this risk disclosure for you");
+  });
+
+  it("waits for explicit risk approval and explicit Create click", async () => {
+    stored("plugin-risk");
+    document.body.innerHTML = customFormHtml();
+    const risk = document.getElementById("trust-checkbox") as HTMLInputElement;
+    const create = document.getElementById("create-custom") as HTMLButtonElement;
+    const createClick = vi.fn();
+    risk.addEventListener("click", () => {
+      create.disabled = false;
+    });
+    create.addEventListener("click", createClick);
+    document.getElementById("custom-form")?.addEventListener("submit", (event) => event.preventDefault());
+    makeGuide();
+    await settle();
+
+    expect(risk.checked).toBe(false);
+    expect(createClick).not.toHaveBeenCalled();
+    risk.click();
+    await settle(120);
+    expect(risk.checked).toBe(true);
+    expect(sessionState()).toMatchObject({ step: "plugin-create" });
+    expect(createClick).not.toHaveBeenCalled();
+
+    create.click();
+    await settle(120);
+    expect(createClick).toHaveBeenCalledTimes(1);
+    expect(sessionState()).toMatchObject({ step: "oauth" });
+  });
+
+  it("reuses an existing exact custom GitHub MCP and skips creation", async () => {
+    stored("plugin-search");
     document.body.innerHTML = `
       <input id="plugin-search" aria-label="Search plugins" value="GitHub MCP" />
       <article><a aria-label="Open GitHub MCP" href="/plugins/custom-github-mcp">GitHub MCP</a></article>`;
     makeGuide();
     await settle();
 
-    expect(sessionState()).toMatchObject({ step: "chat-plus" });
-  });
-
-  it("fills the exact GitHub MCP server URL using native input events", async () => {
-    stored("plugin-server");
-    document.body.innerHTML = `
-      <label for="server-url">Server URL</label>
-      <input id="server-url" type="url" />`;
-    const input = document.getElementById("server-url") as HTMLInputElement;
-    const inputEvent = vi.fn();
-    const changeEvent = vi.fn();
-    input.addEventListener("input", inputEvent);
-    input.addEventListener("change", changeEvent);
-    makeGuide();
-    await settle();
-
-    shadow.querySelector<HTMLButtonElement>('[data-guide-action="fill-url"]')?.click();
-    await settle();
-    expect(input.value).toBe("https://api.githubcopilot.com/mcp/");
-    expect(inputEvent).toHaveBeenCalledTimes(1);
-    expect(changeEvent).toHaveBeenCalledTimes(1);
-    expect(sessionState()).toMatchObject({ step: "plugin-auth" });
+    expect(sessionState()).toMatchObject({ step: "done" });
+    expect(shadow.textContent).toContain("Setup complete");
   });
 });


### PR DESCRIPTION
## Result

Eliminates false/noisy extension warnings on expected non-composer ChatGPT pages, makes composer takeover focus-safe, and turns the opt-in Follow along experience into a largely automated setup for Chat FreePT's dedicated GitHub remote MCP.

## Implementation

- Classifies Plugins and utility pages before waiting for the conversation composer; `/plugins` can host/resume the setup guide without a composer.
- Downgrades expected passive same-conversation ownership messages from warnings to informational state.
- Moves focus out of the native composer before takeover, uses `inert` plus pointer blocking instead of mutating `aria-hidden`, restores the exact prior inert/pointer state, and stops launcher pointer/mouse/click events before ChatGPT popover handlers receive them.
- Targets the current New Plugin form's stable IDs/semantics, including semantic Authentication/OAuth controls as a fallback when IDs drift.
- After the user explicitly chooses Follow along, automatically opens Security and login, finds/enables Developer mode when the host exposes the switch, opens Plugins, searches for the exact dedicated app `Chat FreePT GitHub MCP`, opens Create app if needed, selects Server URL, fills `https://api.githubcopilot.com/mcp/x/all`, and selects OAuth.
- Uses GitHub's remote `/x/all` endpoint because Chat FreePT's release-engineering preflight needs repository, Issue, label, pull-request, Git, and Actions capabilities rather than the smaller default toolset.
- Preserves explicit consent boundaries: the extension never checks ChatGPT's custom-MCP risk acknowledgement and never bypasses GitHub OAuth. Once the user checks the risk acknowledgement, the guide may press Create automatically and continue to the OAuth checkpoint.
- Reuses only the exact dedicated `Chat FreePT GitHub MCP` custom app; the ordinary public GitHub plugin and a generic legacy GitHub MCP result do not count as configured.
- Returns to the originating conversation after OAuth and relies on the real GitHub capability preflight instead of requiring a composer-side `Developer mode → GitHub MCP` menu item.
- Updates generated MCP fallback instructions to the same dedicated-app/full-toolset flow.

## Verification

Hosted run `32941992252` is green on head `1ad58ac027ff8e6652a6b89c7f6ac5d27896daa1`: PR metadata, fast deterministic gates, dependency audit, PR test/build/package, and security workflow policy all pass. Regression coverage includes non-composer route classification, focus-safe inert takeover/restoration, launcher event isolation, tab-session guide resume without a composer, automatic settings/navigation/form fields, exact dedicated-app detection, `/x/all`, explicit risk/OAuth consent boundaries, automatic Create after approval, and current fallback prompts.

Exact installable Actions artifact: `chat-freept-pr-63`, artifact ID `9596848550`. Actions archive SHA-256: `900946e490301d362d42b18a882de481505a12519f4cbc61bd40f3191a06f59a`. Inner installable `chat-freept.zip` SHA-256: `dc7b141d926e33eb54b825b10dab6bbbdd6a5b9402236865da1a2e1e637031b0`.

## Risk

Host-DOM integration risk only. No new extension permissions, host permissions, runtime dependencies, private ChatGPT APIs, network interception, GitHub credentials, or CI threshold changes. Explicit security/OAuth consent remains user-controlled.

## Remaining work

Live-test the exact green artifact on current ChatGPT, including the real custom-MCP OAuth flow and the two console-warning regressions. Do not promote `dev` to `main` until those browser checks pass.

Refs #62