### PR TITLE
Format PR #63 follow-along automation

### DIFF
--- a/.github/workflows/prettier-pr63-followalong-diagnostic.yml
+++ b/.github/workflows/prettier-pr63-followalong-diagnostic.yml
@@ -1,0 +1,40 @@
+name: Prettier PR63 follow-along diagnostic
+
+on:
+  pull_request:
+    branches:
+      - work/62-mcp-setup-accessibility
+
+permissions:
+  contents: write
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: work/62-mcp-setup-accessibility
+          fetch-depth: 0
+      - run: npm ci --no-audit --no-fund
+      - name: Apply repository Prettier
+        run: >-
+          npx prettier --write
+          src/common/prompts.ts
+          src/content/selectors.ts
+          src/content/ui/setup-guide.ts
+          tests/prompts.test.ts
+          tests/selectors.test.ts
+          tests/setup-guide.test.ts
+      - name: Commit exact formatter output to feature branch
+        run: |
+          if git diff --quiet; then
+            echo "Prettier already clean"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/common/prompts.ts src/content/selectors.ts src/content/ui/setup-guide.ts tests/prompts.test.ts tests/selectors.test.ts tests/setup-guide.test.ts
+          git commit -m "style: apply exact Prettier output for PR 63"
+          git push origin HEAD:work/62-mcp-setup-accessibility


### PR DESCRIPTION
## Result

Diagnostic-only formatter workflow for the latest PR #63 Follow along automation changes.

## Implementation

Adds one temporary pull-request workflow on this diagnostic branch. It runs locked `npm ci`, applies the repository Prettier version only to the six files touched by the newest MCP automation update, and pushes only formatter output back to `work/62-mcp-setup-accessibility`.

## Verification

The diagnostic formatter job must succeed. Normal PR #63 CI then verifies the resulting feature branch.

## Risk

`risk:ci`: temporary workflow only. It must never land in the feature branch or `dev`.

## Remaining work

Close this diagnostic PR unmerged, close #66, and verify PR #63 through its normal hosted CI/security pipeline.

Refs #66