### PR TITLE
Promote v0.2.0 pre-test documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,22 @@ and UI.
 ## Requirements
 
 - Chrome (Manifest V3).
-- A ChatGPT account with **Developer Mode connectors** enabled and a **GitHub MCP connector**
-  configured with write access (Settings → Connectors → Advanced → Developer mode; connect
-  GitHub's remote MCP server `https://api.githubcopilot.com/mcp/`). The skill runs a
-  preflight in the conversation and stops with `NEEDS_INPUT` if the tools are missing.
+- A ChatGPT account/workspace where Developer Mode can use a write-capable custom MCP app.
+- The dedicated custom app must be configured as:
+  - **Name:** `Chat FreePT GitHub MCP`
+  - **Server URL:** `https://api.githubcopilot.com/mcp/x/all`
+  - **Authentication:** OAuth
+
+Chat FreePT's **Follow along** setup guides the ChatGPT-side flow through **Settings → Security
+and login → Developer mode → Plugins**, then returns to the originating conversation and
+selects **Developer mode** plus the exact **Chat FreePT GitHub MCP** app before setup is marked
+complete. The extension may fill safe app-configuration fields, but it never approves
+ChatGPT's elevated-risk acknowledgement and never completes or bypasses GitHub OAuth on the
+user's behalf.
+
+The injected skill performs its own GitHub capability preflight in the conversation and stops
+with `NEEDS_INPUT` if the required repository, branch/file, Issue/label, PR/merge, or Actions
+capabilities are unavailable.
 
 ## Install (unpacked)
 
@@ -43,8 +55,12 @@ npm run build
 
 Then Chrome → `chrome://extensions` → Developer mode → **Load unpacked** → select `dist/`.
 
-Open a ChatGPT conversation, click the Chat FreePT launcher in the bottom-right corner,
-describe your idea, and start the plan.
+For release-candidate testing, use the extension ZIP produced by the successful release gate
+instead of rebuilding locally. Extract `chat-freept.zip` to a folder first, then use **Load
+unpacked** on that extracted folder so the browser is testing the exact CI-built package.
+
+Open a ChatGPT conversation and click the Chat FreePT airplane launcher beside the native
+composer **Plus** control. Describe your idea and start the plan.
 
 ## Development
 


### PR DESCRIPTION
Refs #79

## Result
Synchronizes the completed v0.2.0 pre-test documentation from `dev` to production `main`.

## Implementation
- Documentation-only direct `dev → main` promotion.
- Updates the README to the exact dedicated `Chat FreePT GitHub MCP` setup, `/mcp/x/all` endpoint, OAuth handoff, current launcher placement, and CI-built release-package testing instructions.
- No runtime code or release version changes.

## Verification
- Source documentation PR #78 passed PR metadata, fast deterministic gates, dependency audit, full test/build/package, and security workflow.
- Production delta is exactly `README.md`.
- This PR must pass Release metadata, Full regression and production build, release package upload, and security/workflow policy before merge.
- Zero or pending checks are not green.

## Risk
Documentation-only production synchronization. No runtime, authorization, dependency, permission, manifest/package version, or CI-policy changes.

## Remaining work
After all production checks are green, merge to `main`, verify README and v0.2.0 metadata, confirm zero file differences between `dev` and `main`, close #79, and reconcile control Issue #11.